### PR TITLE
Fix/roommate group integrity

### DIFF
--- a/listings/forms.py
+++ b/listings/forms.py
@@ -15,7 +15,6 @@ from .models import (
     ListingReport,
     ListingReview,
     RoommateGroup,
-    RoommateGroupMembership,
     RoommatePost,
 )
 
@@ -587,7 +586,6 @@ class RoommateGroupForm(forms.ModelForm):
             instance.lead = self.user
         if commit:
             instance.save()
-            RoommateGroupMembership.objects.get_or_create(group=instance, user=instance.lead)
         return instance
 
 

--- a/listings/views.py
+++ b/listings/views.py
@@ -29,6 +29,8 @@ from users.compatibility import (
     compute_group_compatibility,
     group_compatibility_highlights,
 )
+from users.group_services import remove_group_member as remove_roommate_group_member
+from users.group_services import save_roommate_group_details
 from users.models import Role, RoommateGroupInvite
 from users.selectors import active_roommate_group_for_user, roommate_group_memberships, roommate_group_profiles_for_user
 
@@ -694,11 +696,12 @@ def save_roommate_group(request):
     current_group = roommate_group_for_user(request.user)
     form = RoommateGroupForm(request.POST, instance=current_group, user=request.user)
     if form.is_valid():
-        group = form.save()
-        group_post = roommate_group_post_for_user(request.user)
-        if group_post is not None:
-            group_post.current_group_size = group.member_count
-            group_post.save(update_fields=["current_group_size", "updated_at"])
+        save_roommate_group_details(
+            lead=request.user,
+            group=current_group,
+            name=form.cleaned_data["name"],
+            description=form.cleaned_data["description"],
+        )
         messages.success(request, "Roommate group saved.")
         return redirect(reverse("listings:roommates_hub") + "?tab=mypost")
 
@@ -812,14 +815,12 @@ def remove_group_member(request, member_pk):
     if not request.user.is_student:
         raise Http404
     membership = get_object_or_404(RoommateGroupMembership, pk=member_pk)
-    group = membership.group
-    if group.lead_id != request.user.id:
-        return HttpResponseForbidden("Only the group leader can remove members.")
-    if membership.user_id == request.user.id:
-        messages.error(request, "You can't remove yourself from the group.")
-        return redirect(reverse("listings:roommates_hub") + "?tab=mypost")
     removed_name = membership.user.display_name
-    membership.delete()
+    try:
+        remove_roommate_group_member(acting_user=request.user, membership=membership)
+    except ValidationError as exc:
+        messages.error(request, exc.messages[0])
+        return redirect(reverse("listings:roommates_hub") + "?tab=mypost")
     messages.success(request, f"Removed {removed_name} from the group.")
     return redirect(reverse("listings:roommates_hub") + "?tab=mypost")
 

--- a/users/group_services.py
+++ b/users/group_services.py
@@ -25,8 +25,58 @@ def _create_group_for_inviter(inviter):
         lead=inviter,
         name=f"{inviter.display_name[:110]}'s Group",
     )
-    RoommateGroupMembership.objects.get_or_create(group=group, user=inviter)
+    _add_group_membership(group, inviter)
     return group
+
+
+def _sync_group_post_size(group):
+    try:
+        roommate_post = group.roommate_post
+    except ListingsRoommateGroup.roommate_post.RelatedObjectDoesNotExist:
+        return
+    current_size = group.member_count
+    if roommate_post.current_group_size == current_size:
+        return
+    roommate_post.current_group_size = current_size
+    roommate_post.save(update_fields=["current_group_size", "updated_at"])
+
+
+def _add_group_membership(group, user):
+    membership, created = RoommateGroupMembership.objects.get_or_create(group=group, user=user)
+    _sync_group_post_size(group)
+    return membership, created
+
+
+def save_roommate_group_details(*, lead, group=None, name, description):
+    _ensure_student_with_profile(lead)
+
+    with transaction.atomic():
+        if group is None:
+            group = ListingsRoommateGroup(lead=lead)
+        elif group.lead_id != lead.id:
+            raise ValidationError("Only the group lead can update this roommate group.")
+
+        group.name = name
+        group.description = description
+        group.save()
+        _add_group_membership(group, lead)
+        return group
+
+
+def remove_group_member(*, acting_user, membership):
+    _ensure_student_with_profile(acting_user)
+
+    with transaction.atomic():
+        membership = RoommateGroupMembership.objects.select_related("group", "user").get(pk=membership.pk)
+        group = membership.group
+        if group.lead_id != acting_user.id:
+            raise ValidationError("Only the group leader can remove members.")
+        if membership.user_id == acting_user.id:
+            raise ValidationError("You can't remove yourself from the group.")
+
+        membership.delete()
+        _sync_group_post_size(group)
+        return group
 
 
 def _create_invite_approvals(invite, inviter):
@@ -78,6 +128,11 @@ def create_group_invite(inviter, invitee):
         if group is None:
             group = _create_group_for_inviter(inviter)
 
+        invitee_group = active_roommate_group_for_user(invitee)
+        if invitee_group is not None:
+            if invitee_group.pk == group.pk:
+                raise ValidationError("This student is already in your group.")
+            raise ValidationError("This student is already in a roommate group.")
         if RoommateGroupMembership.objects.filter(group=group, user=invitee).exists():
             raise ValidationError("This student is already in your group.")
         if RoommateGroupInvite.objects.filter(
@@ -142,7 +197,10 @@ def respond_to_group_invite(invite, invitee, *, accept):
 
         invite.responded_at = timezone.now()
         if accept:
-            RoommateGroupMembership.objects.get_or_create(group=invite.group, user=invitee)
+            existing_group = active_roommate_group_for_user(invitee)
+            if existing_group is not None and existing_group.pk != invite.group_id:
+                raise ValidationError("You are already in a roommate group.")
+            _add_group_membership(invite.group, invitee)
             invite.status = RoommateGroupInvite.STATUS_ACCEPTED
         else:
             invite.status = RoommateGroupInvite.STATUS_REJECTED

--- a/users/management/commands/repair_roommate_group_integrity.py
+++ b/users/management/commands/repair_roommate_group_integrity.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand
+
+from users.roommate_group_integrity import repair_roommate_group_integrity
+
+
+class Command(BaseCommand):
+    help = "Audit and optionally repair roommate-group memberships, invites, and group-post counts."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Persist safe repairs instead of running in audit mode.",
+        )
+
+    def handle(self, *args, **options):
+        apply_changes = options["apply"]
+        summary = repair_roommate_group_integrity(apply=apply_changes)
+
+        mode_label = "repair" if apply_changes else "audit"
+        self.stdout.write(f"Roommate group integrity {mode_label} summary:")
+        self.stdout.write(f"  Groups missing lead membership: {summary['groups_missing_lead_membership']}")
+        self.stdout.write(f"  Lead membership conflicts: {summary['lead_membership_conflicts']}")
+        self.stdout.write(f"  Lead memberships created: {summary['lead_memberships_created']}")
+        self.stdout.write(f"  Group posts out of sync: {summary['group_posts_out_of_sync']}")
+        self.stdout.write(f"  Group posts resynced: {summary['group_posts_resynced']}")
+        self.stdout.write(f"  Invalid active invites: {summary['invalid_active_invites']}")
+        self.stdout.write(f"  Invalid active invites cancelled: {summary['invalid_active_invites_cancelled']}")

--- a/users/roommate_group_integrity.py
+++ b/users/roommate_group_integrity.py
@@ -1,0 +1,82 @@
+from django.db import transaction
+from django.utils import timezone
+
+from listings.models import RoommateGroup, RoommateGroupMembership
+
+from .models import RoommateGroupInvite
+
+ACTIVE_INVITE_STATUSES = [
+    RoommateGroupInvite.STATUS_PENDING_APPROVAL,
+    RoommateGroupInvite.STATUS_PENDING_INVITEE,
+]
+
+
+def repair_roommate_group_integrity(*, apply=False):
+    summary = {
+        "groups_missing_lead_membership": 0,
+        "lead_membership_conflicts": 0,
+        "lead_memberships_created": 0,
+        "group_posts_out_of_sync": 0,
+        "group_posts_resynced": 0,
+        "invalid_active_invites": 0,
+        "invalid_active_invites_cancelled": 0,
+    }
+
+    for group in RoommateGroup.objects.select_related("lead"):
+        has_lead_membership = RoommateGroupMembership.objects.filter(group=group, user=group.lead).exists()
+        if not has_lead_membership:
+            summary["groups_missing_lead_membership"] += 1
+            lead_has_other_group = RoommateGroupMembership.objects.filter(user=group.lead).exclude(group=group).exists()
+            if lead_has_other_group:
+                summary["lead_membership_conflicts"] += 1
+            elif apply:
+                RoommateGroupMembership.objects.create(group=group, user=group.lead)
+                summary["lead_memberships_created"] += 1
+
+        try:
+            group_post = group.roommate_post
+        except RoommateGroup.roommate_post.RelatedObjectDoesNotExist:
+            group_post = None
+
+        if group_post is None:
+            continue
+
+        member_count = RoommateGroupMembership.objects.filter(group=group).count()
+        if group_post.current_group_size != member_count:
+            summary["group_posts_out_of_sync"] += 1
+            if apply:
+                group_post.current_group_size = member_count
+                group_post.save(update_fields=["current_group_size", "updated_at"])
+                summary["group_posts_resynced"] += 1
+
+    active_invites = RoommateGroupInvite.objects.filter(status__in=ACTIVE_INVITE_STATUSES).select_related(
+        "group",
+        "invitee",
+    )
+    for invite in active_invites:
+        invitee_membership = RoommateGroupMembership.objects.filter(user=invite.invitee).first()
+        should_cancel = False
+        if invitee_membership is not None:
+            should_cancel = True
+        elif invite.status == RoommateGroupInvite.STATUS_PENDING_APPROVAL:
+            current_member_ids = set(
+                RoommateGroupMembership.objects.filter(group=invite.group).values_list("user_id", flat=True)
+            )
+            approval_member_ids = set(invite.approvals.values_list("member_id", flat=True))
+            if current_member_ids != approval_member_ids:
+                should_cancel = True
+
+        if not should_cancel:
+            continue
+
+        summary["invalid_active_invites"] += 1
+        if apply:
+            with transaction.atomic():
+                invite = RoommateGroupInvite.objects.select_for_update().get(pk=invite.pk)
+                if invite.status in ACTIVE_INVITE_STATUSES:
+                    invite.status = RoommateGroupInvite.STATUS_CANCELLED
+                    invite.responded_at = timezone.now()
+                    invite.save(update_fields=["status", "responded_at", "updated_at"])
+                    summary["invalid_active_invites_cancelled"] += 1
+
+    return summary

--- a/users/tests/test_groups.py
+++ b/users/tests/test_groups.py
@@ -1,10 +1,12 @@
+from datetime import timedelta
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
 from communications.models import ListingConversation
-from listings.models import RoommateGroup, RoommateGroupMembership
+from listings.models import RoommateGroup, RoommateGroupMembership, RoommatePost
 from users.models import RoommateGroupInvite
 
 
@@ -82,6 +84,78 @@ class RoommateGroupTests(TestCase):
         self.assertTrue(
             ListingConversation.objects.filter(pk=invite.conversation_id, conversation_type="direct").exists()
         )
+
+    def test_cannot_invite_student_who_is_already_in_another_group(self):
+        invitee = self.User.objects.create_user(username="invitee", email="invitee@bc.edu", password="test")
+        other_lead = self.User.objects.create_user(username="other", email="other@bc.edu", password="test")
+        self._complete_profile(invitee)
+        self._complete_profile(other_lead)
+
+        other_group = RoommateGroup.objects.create(lead=other_lead, name="Elsewhere")
+        RoommateGroupMembership.objects.create(group=other_group, user=other_lead)
+        RoommateGroupMembership.objects.create(group=other_group, user=invitee)
+
+        self.client.force_login(self.user)
+        response = self.client.post(reverse("users:send_group_invite", args=[invitee.id]), follow=True)
+
+        self.assertContains(response, "already in a roommate group")
+        self.assertFalse(RoommateGroupInvite.objects.filter(invitee=invitee, inviter=self.user).exists())
+
+    def test_accepting_group_invite_updates_group_post_size(self):
+        invitee = self.User.objects.create_user(username="invitee", email="invitee@bc.edu", password="test")
+        self._complete_profile(invitee)
+
+        group = RoommateGroup.objects.create(lead=self.user, name="Test Group")
+        RoommateGroupMembership.objects.create(group=group, user=self.user)
+        group_post = RoommatePost.objects.create(
+            group=group,
+            title="Need one more",
+            description="Looking for one more roommate for our apartment search.",
+            housing_status=RoommatePost.HOUSING_NEED_HOME,
+            current_group_size=1,
+            open_spots=1,
+            budget_min=1000,
+            budget_max=1400,
+            move_in_date=timezone.localdate() + timedelta(days=30),
+            neighborhoods="Allston",
+        )
+
+        self.client.force_login(self.user)
+        self.client.post(reverse("users:send_group_invite", args=[invitee.id]))
+        invite = RoommateGroupInvite.objects.get(invitee=invitee)
+
+        self.client.force_login(invitee)
+        self.client.post(reverse("users:accept_group_invite", args=[invite.id]))
+
+        group_post.refresh_from_db()
+        self.assertEqual(group_post.current_group_size, 2)
+
+    def test_removing_group_member_updates_group_post_size(self):
+        member = self.User.objects.create_user(username="member", email="member@bc.edu", password="test")
+        self._complete_profile(member)
+
+        group = RoommateGroup.objects.create(lead=self.user, name="Test Group")
+        RoommateGroupMembership.objects.create(group=group, user=self.user)
+        membership = RoommateGroupMembership.objects.create(group=group, user=member)
+        group_post = RoommatePost.objects.create(
+            group=group,
+            title="Quiet two-person search",
+            description="We want a calm apartment and are narrowing down our shortlist.",
+            housing_status=RoommatePost.HOUSING_NEED_HOME,
+            current_group_size=2,
+            open_spots=1,
+            budget_min=1000,
+            budget_max=1400,
+            move_in_date=timezone.localdate() + timedelta(days=30),
+            neighborhoods="Brighton",
+        )
+
+        self.client.force_login(self.user)
+        response = self.client.post(reverse("listings:remove_group_member", args=[membership.id]))
+
+        self.assertEqual(response.status_code, 302)
+        group_post.refresh_from_db()
+        self.assertEqual(group_post.current_group_size, 1)
 
     def test_browse_roommates_uses_group_compatibility(self):
         buddy = self.User.objects.create_user(username="buddy", email="buddy@bc.edu", password="test")

--- a/users/tests/test_management.py
+++ b/users/tests/test_management.py
@@ -1,10 +1,14 @@
+from datetime import timedelta
 from io import StringIO
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
+from django.utils import timezone
 
-from ..models import Role
+from listings.models import RoommateGroup, RoommateGroupMembership, RoommatePost
+
+from ..models import Role, RoommateGroupInvite
 from .helpers import User
 
 
@@ -45,3 +49,96 @@ class SetUserRoleCommandTests(TestCase):
     def test_nonexistent_user_raises(self):
         with self.assertRaises(CommandError):
             call_command("set_user_role", "nobody@bc.edu", "admin", stderr=StringIO())
+
+
+class RepairRoommateGroupIntegrityCommandTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="leader", email="leader@bc.edu", password="test")
+
+    def _complete_profile(self, user, **overrides):
+        profile = user.student_profile
+        defaults = {
+            "preferred_name": user.first_name or user.username,
+            "major": "Computer Science",
+            "bio": "Easygoing roommate.",
+            "messy_level": 5,
+            "guest_level": 3,
+            "bedtime": 23,
+            "noise_level": 5,
+            "smoke": True,
+            "drink": 5,
+            "party": 5,
+            "pets": True,
+        }
+        defaults.update(overrides)
+        for field_name, value in defaults.items():
+            setattr(profile, field_name, value)
+        profile.save()
+        user.profile_completed_at = timezone.now()
+        user.save(update_fields=["profile_completed_at"])
+
+    def test_audit_mode_reports_but_does_not_repair(self):
+        self._complete_profile(self.user)
+        group = RoommateGroup.objects.create(lead=self.user, name="Audit Group")
+        output = StringIO()
+
+        call_command("repair_roommate_group_integrity", stdout=output)
+
+        self.assertIn("Groups missing lead membership: 1", output.getvalue())
+        self.assertFalse(RoommateGroupMembership.objects.filter(group=group, user=self.user).exists())
+
+    def test_apply_mode_creates_missing_lead_membership_and_resyncs_group_post(self):
+        self._complete_profile(self.user)
+        group = RoommateGroup.objects.create(lead=self.user, name="Repair Group")
+        lead_membership = RoommateGroupMembership.objects.create(group=group, user=self.user)
+        roommate_post = RoommatePost.objects.create(
+            group=group,
+            title="Need one more",
+            description="Looking for one more roommate for a late-summer apartment search.",
+            housing_status=RoommatePost.HOUSING_NEED_HOME,
+            current_group_size=1,
+            open_spots=1,
+            budget_min=1000,
+            budget_max=1400,
+            move_in_date=timezone.localdate() + timedelta(days=30),
+            neighborhoods="Allston",
+        )
+        RoommatePost.objects.filter(pk=roommate_post.pk).update(current_group_size=99)
+        lead_membership.delete()
+        output = StringIO()
+
+        call_command("repair_roommate_group_integrity", "--apply", stdout=output)
+
+        self.assertTrue(RoommateGroupMembership.objects.filter(group=group, user=self.user).exists())
+        roommate_post.refresh_from_db()
+        self.assertEqual(roommate_post.current_group_size, 1)
+        self.assertIn("Lead memberships created: 1", output.getvalue())
+        self.assertIn("Group posts resynced: 1", output.getvalue())
+
+    def test_apply_mode_cancels_active_invite_for_user_already_in_group(self):
+        invitee = User.objects.create_user(username="invitee", email="invitee@bc.edu", password="test")
+        other_lead = User.objects.create_user(username="other", email="other@bc.edu", password="test")
+        self._complete_profile(self.user)
+        self._complete_profile(invitee)
+        self._complete_profile(other_lead)
+
+        inviting_group = RoommateGroup.objects.create(lead=self.user, name="Inviting Group")
+        RoommateGroupMembership.objects.create(group=inviting_group, user=self.user)
+        other_group = RoommateGroup.objects.create(lead=other_lead, name="Other Group")
+        RoommateGroupMembership.objects.create(group=other_group, user=other_lead)
+        RoommateGroupMembership.objects.create(group=other_group, user=invitee)
+
+        invite = RoommateGroupInvite.objects.create(
+            group=inviting_group,
+            inviter=self.user,
+            invitee=invitee,
+            status=RoommateGroupInvite.STATUS_PENDING_INVITEE,
+        )
+        output = StringIO()
+
+        call_command("repair_roommate_group_integrity", "--apply", stdout=output)
+
+        invite.refresh_from_db()
+        self.assertEqual(invite.status, RoommateGroupInvite.STATUS_CANCELLED)
+        self.assertIsNotNone(invite.responded_at)
+        self.assertIn("Invalid active invites cancelled: 1", output.getvalue())


### PR DESCRIPTION
- Move roommate group membership mutations behind service helpers
- Keep invite acceptance as the only path for adding non-lead members
- Block cross-group invites and accepts before they hit DB constraints
- Add an audit/repair command for roommate-group integrity issues
- Expand regression coverage for invites, membership updates, and integrity repairs
