### PR TITLE
Fix settings bootstrap when dj-database-url is missing

### DIFF
--- a/core/tests/test_settings.py
+++ b/core/tests/test_settings.py
@@ -1,3 +1,9 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
 from django.conf import settings
 from django.test import SimpleTestCase
 
@@ -5,3 +11,55 @@ from django.test import SimpleTestCase
 class TestSettingsTests(SimpleTestCase):
     def test_test_suite_uses_fast_password_hasher(self):
         self.assertEqual(settings.PASSWORD_HASHERS, ["django.contrib.auth.hashers.MD5PasswordHasher"])
+
+    def test_settings_fall_back_to_sqlite_when_database_url_package_is_missing(self):
+        result = self._run_settings_import_with_blocked_dj_database_url(
+            "import vibecoders.settings as settings; print(settings.DATABASES['default']['ENGINE'])"
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("django.db.backends.sqlite3", result.stdout)
+
+    def test_settings_require_dj_database_url_when_database_url_is_set(self):
+        result = self._run_settings_import_with_blocked_dj_database_url(
+            "import vibecoders.settings",
+            database_url="postgres://user:pass@localhost:5432/padly",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Install dj-database-url to use DATABASE_URL.", result.stderr)
+
+    def _run_settings_import_with_blocked_dj_database_url(self, command, *, database_url=""):
+        repo_root = Path(__file__).resolve().parents[2]
+        import_blocker = "\n".join(
+            [
+                "import builtins",
+                "_real_import = builtins.__import__",
+                "def _blocked(name, globals=None, locals=None, fromlist=(), level=0):",
+                "    if name == 'dj_database_url':",
+                "        raise ImportError('blocked for test')",
+                "    return _real_import(name, globals, locals, fromlist, level)",
+                "builtins.__import__ = _blocked",
+            ]
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            sitecustomize_path = Path(temp_dir) / "sitecustomize.py"
+            sitecustomize_path.write_text(import_blocker, encoding="utf-8")
+
+            env = os.environ.copy()
+            env["DJANGO_DEBUG"] = "true"
+            env["PYTHONPATH"] = os.pathsep.join([temp_dir, str(repo_root)])
+            if database_url:
+                env["DATABASE_URL"] = database_url
+            else:
+                env.pop("DATABASE_URL", None)
+
+            return subprocess.run(
+                [sys.executable, "-c", command],
+                capture_output=True,
+                check=False,
+                cwd=repo_root,
+                env=env,
+                text=True,
+            )

--- a/vibecoders/settings.py
+++ b/vibecoders/settings.py
@@ -14,9 +14,13 @@ import os
 import sys
 from pathlib import Path
 
-import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 from dotenv import load_dotenv
+
+try:
+    import dj_database_url
+except ImportError:  # pragma: no cover - exercised via subprocess tests.
+    dj_database_url = None
 
 load_dotenv()
 
@@ -169,6 +173,8 @@ if not DEBUG and not DATABASE_URL:
     raise ImproperlyConfigured("Set DATABASE_URL when running with DJANGO_DEBUG=false.")
 
 if DATABASE_URL:
+    if dj_database_url is None:
+        raise ImproperlyConfigured("Install dj-database-url to use DATABASE_URL.")
     DATABASES = {"default": dj_database_url.parse(DATABASE_URL, conn_max_age=600)}
 else:
     DATABASES = {


### PR DESCRIPTION
## Summary
- make `dj-database-url` optional at import time so local SQLite startup still works without the package installed
- keep production-style `DATABASE_URL` usage explicit by raising `ImproperlyConfigured` when the package is missing but `DATABASE_URL` is set
- add settings tests covering both the local SQLite fallback path and the `DATABASE_URL` error path

## Verification
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python manage.py test`
- `python manage.py migrate`

## Context
This fixes the regression where `python manage.py migrate` failed during settings import with `ModuleNotFoundError: No module named 'dj_database_url'` in local environments using the default SQLite configuration.