### PR TITLE
Clarify Inversed Groupmatch

### DIFF
--- a/listings/forms.py
+++ b/listings/forms.py
@@ -406,6 +406,7 @@ class RoommatePostForm(forms.ModelForm):
         fields = [
             "title",
             "housing_status",
+            "address",
             "current_group_size",
             "open_spots",
             "budget_min",
@@ -417,6 +418,7 @@ class RoommatePostForm(forms.ModelForm):
         widgets = {
             "title": forms.TextInput(attrs={"placeholder": "Two BC seniors looking for one more roommate"}),
             "housing_status": forms.Select(attrs={"class": "form-select"}),
+            "address": forms.TextInput(attrs={"placeholder": "123 College Rd, Boston, MA"}),
             "current_group_size": forms.NumberInput(attrs={"min": 1, "max": 8}),
             "open_spots": forms.NumberInput(attrs={"min": 1, "max": 8}),
             "budget_min": forms.NumberInput(attrs={"min": 0, "step": 50, "placeholder": "1200"}),
@@ -436,6 +438,7 @@ class RoommatePostForm(forms.ModelForm):
         labels = {
             "title": "Post title",
             "housing_status": "Housing stage",
+            "address": "Your place address",
             "current_group_size": "People already in the group",
             "open_spots": "Open roommate spots",
             "budget_min": "Budget min / person",
@@ -465,6 +468,7 @@ class RoommatePostForm(forms.ModelForm):
         )
         self.fields["housing_status"].label = housing_label
         self.fields["housing_status"].help_text = housing_help
+        self.fields["address"].help_text = "Required for all new posts. We’ll try to link the listing automatically."
 
         if not self.is_bound and not getattr(self.instance, "pk", None):
             self.fields["move_in_date"].initial = timezone.localdate() + timedelta(days=30)
@@ -518,10 +522,16 @@ class RoommatePostForm(forms.ModelForm):
         move_in_date = cleaned_data.get("move_in_date")
         housing_status = cleaned_data.get("housing_status")
         open_spots = cleaned_data.get("open_spots")
+        address = (cleaned_data.get("address") or "").strip()
+        cleaned_data["address"] = address
         if housing_status == RoommatePost.HOUSING_HAVE_HOME and open_spots is None:
             self.add_error("open_spots", "Add how many open roommate spots you have.")
         if open_spots is not None and open_spots < 1:
             self.add_error("open_spots", "Open roommate spots must be at least 1.")
+        if not address:
+            self.add_error("address", "Add the address so people know where the group wants to live.")
+        if housing_status != RoommatePost.HOUSING_HAVE_HOME:
+            cleaned_data["open_spots"] = open_spots if open_spots else None
         if move_in_date and move_in_date < timezone.localdate():
             self.add_error("move_in_date", "Move-in date must be today or later.")
         return cleaned_data
@@ -536,6 +546,21 @@ class RoommatePostForm(forms.ModelForm):
         elif self.user is not None and instance.author_id is None:
             instance.author = self.user
             instance.group = None
+        instance.address = (self.cleaned_data.get("address") or "").strip()
+        if instance.housing_status == RoommatePost.HOUSING_HAVE_HOME:
+            match = (
+                Listing.objects.filter(
+                    address__iexact=instance.address,
+                    approval_status=Listing.APPROVAL_APPROVED,
+                    status=Listing.STATUS_AVAILABLE,
+                    is_hidden=False,
+                )
+                .order_by("-updated_at")
+                .first()
+            )
+            instance.linked_listing = match
+        else:
+            instance.linked_listing = None
         if commit:
             instance.save()
         return instance

--- a/listings/forms.py
+++ b/listings/forms.py
@@ -457,6 +457,15 @@ class RoommatePostForm(forms.ModelForm):
                 css_class = field.widget.attrs.get("class", "")
                 field.widget.attrs["class"] = f"{css_class} form-control".strip()
 
+        # Make the matching intent explicit: we show the complementary side.
+        housing_label = "Your housing stage (we'll match you with the opposite side)"
+        housing_help = (
+            "Pick your situation. If you already have a place, you'll see people who need one. "
+            "If you still need a place, you'll see groups with room or others also looking."
+        )
+        self.fields["housing_status"].label = housing_label
+        self.fields["housing_status"].help_text = housing_help
+
         if not self.is_bound and not getattr(self.instance, "pk", None):
             self.fields["move_in_date"].initial = timezone.localdate() + timedelta(days=30)
         if self.group is not None:
@@ -590,6 +599,14 @@ class RoommateGroupForm(forms.ModelForm):
 
 
 class RoommatePostFilterForm(forms.Form):
+    HOUSING_FILTER_CHOICES = [
+        ("", "Any stage"),
+        (RoommatePost.HOUSING_HAVE_HOME, "I already have a place (find people who need one)"),
+        (
+            RoommatePost.HOUSING_NEED_HOME,
+            "I need a place (show groups with room or also looking)",
+        ),
+    ]
     OPEN_SPOT_CHOICES = [
         ("", "Any open spots"),
         ("1", "1+ spot"),
@@ -609,9 +626,10 @@ class RoommatePostFilterForm(forms.Form):
     )
     housing_status = forms.ChoiceField(
         required=False,
-        label="Housing stage",
-        choices=[("", "Any stage"), *RoommatePost.HOUSING_CHOICES],
+        label="Who do you want to see?",
+        choices=HOUSING_FILTER_CHOICES,
         widget=forms.Select(attrs={"class": "form-select"}),
+        help_text="We’ll show the opposite side: people who need a place or groups with space.",
     )
     max_budget = forms.DecimalField(
         required=False,

--- a/listings/migrations/0025_roommatepost_address_and_linked_listing.py
+++ b/listings/migrations/0025_roommatepost_address_and_linked_listing.py
@@ -1,0 +1,34 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("listings", "0024_one_group_per_user"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="roommatepost",
+            name="address",
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name="roommatepost",
+            name="linked_listing",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="roommate_posts",
+                to="listings.listing",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="roommatepost",
+            constraint=models.CheckConstraint(
+                condition=models.Q(("housing_status", "need_home")) | ~models.Q(("address", "")),
+                name="roommate_post_address_required_for_have_home",
+            ),
+        ),
+    ]

--- a/listings/models.py
+++ b/listings/models.py
@@ -119,6 +119,7 @@ class RoommatePostQuerySet(models.QuerySet):
             "group",
             "group__lead",
             "group__lead__student_profile",
+            "linked_listing",
         ).prefetch_related(
             "author__socialaccount_set",
             "group__lead__socialaccount_set",
@@ -623,6 +624,10 @@ class RoommatePost(models.Model):
     )
     current_group_size = models.PositiveSmallIntegerField(default=1)
     open_spots = models.PositiveSmallIntegerField(default=None, null=True, blank=True)
+    address = models.CharField(max_length=255, blank=True)
+    linked_listing = models.ForeignKey(
+        Listing, null=True, blank=True, on_delete=models.SET_NULL, related_name="roommate_posts"
+    )
     budget_min = models.DecimalField(max_digits=8, decimal_places=0)
     budget_max = models.DecimalField(max_digits=8, decimal_places=0)
     move_in_date = models.DateField(db_index=True)
@@ -661,6 +666,10 @@ class RoommatePost(models.Model):
                     )
                 ),
                 name="roommate_post_open_spots_valid",
+            ),
+            models.CheckConstraint(
+                condition=Q(housing_status=ROOMMATE_POST_HOUSING_NEED_HOME) | ~Q(address=""),
+                name="roommate_post_address_required_for_have_home",
             ),
             models.CheckConstraint(
                 condition=Q(budget_min__gte=0),

--- a/listings/selectors.py
+++ b/listings/selectors.py
@@ -176,7 +176,11 @@ def filtered_roommate_posts_queryset(
         if housing_status == RoommatePost.HOUSING_HAVE_HOME:
             queryset = queryset.filter(housing_status=RoommatePost.HOUSING_NEED_HOME)
         else:
-            queryset = queryset.filter(housing_status=housing_status)
+            needs_place_q = Q(housing_status=RoommatePost.HOUSING_NEED_HOME)
+            have_home_with_space_q = Q(housing_status=RoommatePost.HOUSING_HAVE_HOME)
+            if people_in_group is not None:
+                have_home_with_space_q &= Q(open_spots__gte=people_in_group)
+            queryset = queryset.filter(needs_place_q | have_home_with_space_q)
     if max_budget is not None:
         queryset = queryset.filter(budget_min__lte=max_budget)
     if move_in_by is not None:

--- a/static/js/group-match.js
+++ b/static/js/group-match.js
@@ -8,7 +8,7 @@
     };
 
     onReady(() => {
-    const setupOpenSpotsToggle = (form, fieldSelector) => {
+    const setupHousingDependentToggle = (form, fieldSelector, shouldShow) => {
         if (!form) {
             return;
         }
@@ -19,9 +19,9 @@
         }
         const openSpotsInput = openSpotsField.querySelector("input, select, textarea");
 
-        const toggleOpenSpots = () => {
-            const shouldShow = housingSelect.value === "have_home";
-            if (shouldShow) {
+        const toggleField = () => {
+            const show = shouldShow(housingSelect.value);
+            if (show) {
                 openSpotsField.removeAttribute("hidden");
                 openSpotsField.style.display = "";
             } else {
@@ -29,20 +29,33 @@
                 openSpotsField.style.display = "none";
             }
             if (openSpotsInput) {
-                openSpotsInput.disabled = !shouldShow;
+                openSpotsInput.disabled = !show;
             }
         };
 
-        toggleOpenSpots();
-        housingSelect.addEventListener("change", toggleOpenSpots);
-        housingSelect.addEventListener("input", toggleOpenSpots);
+        toggleField();
+        housingSelect.addEventListener("change", toggleField);
+        housingSelect.addEventListener("input", toggleField);
     };
 
     document.querySelectorAll(".group-board-filter-form").forEach((form) => {
-        setupOpenSpotsToggle(form, ".js-open-spots-filter");
+        setupHousingDependentToggle(form, ".js-open-spots-filter", (value) => value === "have_home");
     });
     document.querySelectorAll(".group-board-post-form").forEach((form) => {
-        setupOpenSpotsToggle(form, ".js-open-spots-post");
+        setupHousingDependentToggle(form, ".js-open-spots-post", (value) => value === "have_home");
+    });
+
+    // Toggle linked listing expansion when clicking the post title button
+    document.querySelectorAll(".js-toggle-linked-listing").forEach((button) => {
+        const targetId = button.getAttribute("data-target");
+        if (!targetId) return;
+        const target = document.querySelector(targetId);
+        if (!target) return;
+        button.addEventListener("click", () => {
+            const isHidden = target.hasAttribute("hidden");
+            target.toggleAttribute("hidden", !isHidden);
+            button.setAttribute("aria-expanded", isHidden ? "true" : "false");
+        });
     });
     });
 })();

--- a/templates/listings/group_match.html
+++ b/templates/listings/group_match.html
@@ -160,6 +160,7 @@
                                     <div class="group-board-form-stack">
                                         {% include "listings/includes/form_field.html" with field=roommate_post_form.title wrapper_class="group-board-field" %}
                                         {% include "listings/includes/form_field.html" with field=roommate_post_form.housing_status wrapper_class="group-board-field" %}
+                                        {% include "listings/includes/form_field.html" with field=roommate_post_form.address wrapper_class="group-board-field" %}
 
                                         <div class="group-board-field-grid group-board-field-grid-3">
                                             {% include "listings/includes/form_field.html" with field=roommate_post_form.current_group_size wrapper_class="group-board-field" %}
@@ -252,6 +253,7 @@
                                     <div class="group-board-form-stack">
                                         {% include "listings/includes/form_field.html" with field=roommate_group_post_form.title wrapper_class="group-board-field" %}
                                         {% include "listings/includes/form_field.html" with field=roommate_group_post_form.housing_status wrapper_class="group-board-field" %}
+                                        {% include "listings/includes/form_field.html" with field=roommate_group_post_form.address wrapper_class="group-board-field" %}
 
                                         <div class="group-board-field-grid group-board-field-grid-3">
                                             {% include "listings/includes/form_field.html" with field=roommate_group_post_form.current_group_size wrapper_class="group-board-field" %}
@@ -370,7 +372,15 @@
                                                 {% include "includes/user_avatar.html" with user_obj=post.lead_user avatar_class="user-avatar user-avatar-lg" %}
                                                 <div class="identity-copy">
                                                     <p class="group-post-overline">{{ post.ui_owner_meta }}</p>
-                                                    <h3 class="group-post-title">{{ post.title }}</h3>
+                                                    <h3 class="group-post-title">
+                                                        {% if post.linked_listing %}
+                                                            <button class="group-post-title-btn js-toggle-linked-listing" type="button" data-target="#linked-listing-{{ post.pk }}" aria-expanded="false">
+                                                                {{ post.title }}
+                                                            </button>
+                                                        {% else %}
+                                                            {{ post.title }}
+                                                        {% endif %}
+                                                    </h3>
                                                     {% if post.group_id %}
                                                         <p class="group-post-subtitle">{{ post.group.name }}</p>
                                                     {% endif %}
@@ -445,6 +455,12 @@
                                                 {% for highlight in post.ui_highlights %}
                                                     <span>{{ highlight }}</span>
                                                 {% endfor %}
+                                            </div>
+                                        {% endif %}
+
+                                        {% if post.linked_listing %}
+                                            <div id="linked-listing-{{ post.pk }}" class="group-post-linked-listing" hidden>
+                                                {% include "listings/includes/listing_result_card.html" with listing=post.linked_listing %}
                                             </div>
                                         {% endif %}
 

--- a/templates/listings/roommates_hub.html
+++ b/templates/listings/roommates_hub.html
@@ -466,6 +466,7 @@
                                                             <div class="group-board-form-stack">
                                                                 {% include "listings/includes/form_field.html" with field=edit_form.title wrapper_class="group-board-field" %}
                                                                 {% include "listings/includes/form_field.html" with field=edit_form.housing_status wrapper_class="group-board-field" %}
+                                                                {% include "listings/includes/form_field.html" with field=edit_form.address wrapper_class="group-board-field" %}
                                                                 <div class="group-board-field-grid group-board-field-grid-3">
                                                                     {% include "listings/includes/form_field.html" with field=edit_form.current_group_size wrapper_class="group-board-field" %}
                                                                     {% if edit_form.housing_status.value == "have_home" %}
@@ -597,6 +598,7 @@
             <div class="group-board-form-stack">
                 {% include "listings/includes/form_field.html" with field=roommate_post_create_form.title wrapper_class="group-board-field" %}
                 {% include "listings/includes/form_field.html" with field=roommate_post_create_form.housing_status wrapper_class="group-board-field" %}
+                {% include "listings/includes/form_field.html" with field=roommate_post_create_form.address wrapper_class="group-board-field" %}
                 <div class="group-board-field-grid group-board-field-grid-3">
                     {% include "listings/includes/form_field.html" with field=roommate_post_create_form.current_group_size wrapper_class="group-board-field" %}
                     {% if roommate_post_create_form.housing_status.value == "have_home" %}


### PR DESCRIPTION
1. Roommate “Have Home” filtering is inverted. Severity: High. Area: roommate matching.
     Why: users selecting “already have a place” get need_home posts instead. Evidence: listings/
     selectors.py:175 maps HAVE_HOME to NEED_HOME; listings/tests/test_pages.py:2494 asserts that
     inverted behavior. Impact: wrong matches in a core workflow. Fix: filter exact status, add any
     “complementary match” logic as a separate filter, and rewrite the regression test. Difficulty:
     Small.