### PR TITLE
Refactor roommate matching performance and centralize ranking logic

### DIFF
--- a/listings/views.py
+++ b/listings/views.py
@@ -4,10 +4,8 @@ import re
 import requests
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
-from django.db.models import Q
 from django.http import Http404, HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -23,16 +21,15 @@ from communications.services import (
 )
 from core.rate_limits import consume_rate_limit, request_rate_limit_identifier
 from core.utils import get_page, preserved_query_suffix, safe_next_url
-from users.compatibility import (
-    compatibility_highlights,
-    compute_compatibility,
-    compute_group_compatibility,
-    group_compatibility_highlights,
-)
 from users.group_services import remove_group_member as remove_roommate_group_member
 from users.group_services import save_roommate_group_details
-from users.models import Role, RoommateGroupInvite
-from users.selectors import active_roommate_group_for_user, roommate_group_memberships, roommate_group_profiles_for_user
+from users.models import RoommateGroupInvite
+from users.selectors import (
+    active_roommate_group_for_user,
+    roommate_candidate_results,
+    roommate_group_memberships,
+    roommate_group_profiles_for_user,
+)
 
 from .address_provider import get_geoapify_autocomplete_config, normalize_geoapify_suggestions
 from .address_signing import sign_address_selection
@@ -502,53 +499,22 @@ def _posts_tab_context(request):
 
 
 def _people_tab_context(request):
-    User = get_user_model()
     query = request.GET.get("q", "").strip()
     gender_filter = request.GET.get("gender", "").strip()
     smoke_filter = request.GET.get("smoke", "").strip()
     pets_filter = request.GET.get("pets", "").strip()
     min_score_raw = request.GET.get("min_score", "").strip()
     min_score = int(min_score_raw) if min_score_raw.isdigit() else None
-
     my_profile = getattr(request.user, "student_profile", None)
-    group_profiles = roommate_group_profiles_for_user(request.user)
 
-    students_qs = (
-        User.objects.filter(role=Role.STUDENT, is_active=True, profile_completed_at__isnull=False)
-        .exclude(id=request.user.id)
-        .select_related("student_profile")
-        .order_by("first_name", "last_name", "id")
+    results = roommate_candidate_results(
+        request.user,
+        query=query,
+        gender_filter=gender_filter,
+        smoke_filter=smoke_filter,
+        pets_filter=pets_filter,
+        min_score=min_score,
     )
-    if query:
-        students_qs = students_qs.filter(
-            Q(first_name__icontains=query)
-            | Q(last_name__icontains=query)
-            | Q(student_profile__preferred_name__icontains=query)
-        )
-    if gender_filter:
-        students_qs = students_qs.filter(student_profile__gender=gender_filter)
-    if smoke_filter == "yes":
-        students_qs = students_qs.filter(student_profile__smoke=True)
-    elif smoke_filter == "no":
-        students_qs = students_qs.filter(student_profile__smoke=False)
-    if pets_filter == "yes":
-        students_qs = students_qs.filter(student_profile__pets=True)
-    elif pets_filter == "no":
-        students_qs = students_qs.filter(student_profile__pets=False)
-
-    results = []
-    for student in students_qs:
-        their_profile = getattr(student, "student_profile", None)
-        if group_profiles:
-            score = compute_group_compatibility(group_profiles, their_profile) if their_profile else None
-            highlights = group_compatibility_highlights(group_profiles, their_profile) if their_profile else []
-        else:
-            score = compute_compatibility(my_profile, their_profile) if my_profile and their_profile else None
-            highlights = compatibility_highlights(my_profile, their_profile)
-        if min_score is not None and (score is None or score < min_score):
-            continue
-        results.append({"user": student, "profile": their_profile, "score": score, "highlights": highlights})
-    results.sort(key=lambda r: r["score"] if r["score"] is not None else -1, reverse=True)
     people_results_page = get_page(results, request.GET.get("page"), ROOMMATE_PEOPLE_PER_PAGE)
     page_results = list(people_results_page.object_list)
 

--- a/users/selectors.py
+++ b/users/selectors.py
@@ -4,13 +4,78 @@ from django.db.models import Case, Count, IntegerField, Q, Value, When
 from listings.models import Listing, ListingReport, RoommateGroupMembership
 from listings.selectors import listing_reports_queryset_for_admin, with_feedback_summary
 
-from .compatibility import compatibility_highlights, compute_compatibility
+from .compatibility import (
+    compatibility_highlights,
+    compute_compatibility,
+    compute_group_compatibility,
+    group_compatibility_highlights,
+)
 from .models import (
     Role,
     RoommateGroupInvite,
     RoommateGroupInviteApproval,
     UserFile,
 )
+
+
+def roommate_candidate_results(
+    user,
+    *,
+    query="",
+    gender_filter="",
+    smoke_filter="",
+    pets_filter="",
+    min_score=None,
+):
+    """
+    Shared roommate-people ranking used by browse and hub:
+    - Pulls active, completed student profiles (excluding the requester)
+    - Applies basic field filters in SQL
+    - Computes compatibility in Python for ranking and highlights
+    - Returns list of dicts {user, profile, score, highlights}
+    """
+    User = get_user_model()
+    my_profile = getattr(user, "student_profile", None)
+    group_profiles = roommate_group_profiles_for_user(user)
+
+    students_qs = (
+        User.objects.filter(role=Role.STUDENT, is_active=True, profile_completed_at__isnull=False)
+        .exclude(id=user.id)
+        .select_related("student_profile")
+        .order_by("first_name", "last_name", "id")
+    )
+    if query:
+        students_qs = students_qs.filter(
+            Q(first_name__icontains=query)
+            | Q(last_name__icontains=query)
+            | Q(student_profile__preferred_name__icontains=query)
+        )
+    if gender_filter:
+        students_qs = students_qs.filter(student_profile__gender=gender_filter)
+    if smoke_filter == "yes":
+        students_qs = students_qs.filter(student_profile__smoke=True)
+    elif smoke_filter == "no":
+        students_qs = students_qs.filter(student_profile__smoke=False)
+    if pets_filter == "yes":
+        students_qs = students_qs.filter(student_profile__pets=True)
+    elif pets_filter == "no":
+        students_qs = students_qs.filter(student_profile__pets=False)
+
+    results = []
+    for student in students_qs:
+        their_profile = getattr(student, "student_profile", None)
+        if group_profiles:
+            score = compute_group_compatibility(group_profiles, their_profile) if their_profile else None
+            highlights = group_compatibility_highlights(group_profiles, their_profile) if their_profile else []
+        else:
+            score = compute_compatibility(my_profile, their_profile) if my_profile and their_profile else None
+            highlights = compatibility_highlights(my_profile, their_profile)
+        if min_score is not None and (score is None or score < min_score):
+            continue
+        results.append({"user": student, "profile": their_profile, "score": score, "highlights": highlights})
+
+    results.sort(key=lambda r: r["score"] if r["score"] is not None else -1, reverse=True)
+    return results
 
 
 def admin_listings_queryset(query="", selected_status="", selected_review_status=""):

--- a/users/views.py
+++ b/users/views.py
@@ -46,6 +46,7 @@ from .selectors import (
     active_roommate_group_for_user,
     pending_group_invite_approvals_for_user,
     pending_group_invites_for_user,
+    roommate_candidate_results,
     roommate_group_memberships,
     roommate_group_profiles_for_user,
 )
@@ -442,7 +443,6 @@ def upload_avatar(request):
 def browse_roommates(request):
     if not request.user.is_student:
         raise Http404
-    User = get_user_model()
     query = request.GET.get("q", "").strip()
     gender_filter = request.GET.get("gender", "").strip()
     smoke_filter = request.GET.get("smoke", "").strip()
@@ -451,67 +451,21 @@ def browse_roommates(request):
     min_score = int(min_score_raw) if min_score_raw.isdigit() else None
 
     my_profile = getattr(request.user, "student_profile", None)
-    group_profiles = roommate_group_profiles_for_user(request.user)
     active_group = active_roommate_group_for_user(request.user)
     group_memberships = roommate_group_memberships(active_group) if active_group else []
     group_member_ids = {membership.user_id for membership in group_memberships}
 
-    students_qs = (
-        User.objects.filter(
-            role=Role.STUDENT,
-            is_active=True,
-            profile_completed_at__isnull=False,
-        )
-        .exclude(id=request.user.id)
-        .select_related("student_profile")
-        .order_by("first_name", "last_name", "id")
+    results = roommate_candidate_results(
+        request.user,
+        query=query,
+        gender_filter=gender_filter,
+        smoke_filter=smoke_filter,
+        pets_filter=pets_filter,
+        min_score=min_score,
     )
+    for result in results:
+        result["is_in_group"] = result["user"].id in group_member_ids
 
-    if query:
-        students_qs = students_qs.filter(
-            Q(first_name__icontains=query)
-            | Q(last_name__icontains=query)
-            | Q(student_profile__preferred_name__icontains=query)
-        )
-    if gender_filter:
-        students_qs = students_qs.filter(student_profile__gender=gender_filter)
-    if smoke_filter == "yes":
-        students_qs = students_qs.filter(student_profile__smoke=True)
-    elif smoke_filter == "no":
-        students_qs = students_qs.filter(student_profile__smoke=False)
-    if pets_filter == "yes":
-        students_qs = students_qs.filter(student_profile__pets=True)
-    elif pets_filter == "no":
-        students_qs = students_qs.filter(student_profile__pets=False)
-
-    results = []
-    for student in students_qs:
-        their_profile = getattr(student, "student_profile", None)
-        if group_profiles:
-            score = (
-                compute_group_compatibility(group_profiles, their_profile) if group_profiles and their_profile else None
-            )
-            highlights = (
-                group_compatibility_highlights(group_profiles, their_profile)
-                if group_profiles and their_profile
-                else []
-            )
-        else:
-            score = compute_compatibility(my_profile, their_profile) if my_profile and their_profile else None
-            highlights = compatibility_highlights(my_profile, their_profile)
-        if min_score is not None and (score is None or score < min_score):
-            continue
-        results.append(
-            {
-                "user": student,
-                "profile": their_profile,
-                "score": score,
-                "highlights": highlights,
-                "is_in_group": student.id in group_member_ids,
-            }
-        )
-
-    results.sort(key=lambda r: r["score"] if r["score"] is not None else -1, reverse=True)
     results_page = get_page(results, request.GET.get("page"), ROOMMATE_RESULTS_PER_PAGE)
     page_results = list(results_page.object_list)
 


### PR DESCRIPTION
  2. Roommate compatibility scoring does full Python-side ranking before pagination in two active flows.
     Severity: High. Area: roommate matching performance/maintainability.
     Why: both the legacy browse page and the newer roommates hub load all completed students, compute
     compatibility in Python, sort in memory, then paginate. Evidence: users/views.py:459 and listings/
     views.py:516. Impact: request cost grows linearly with the number of students, and the duplicated
     logic is likely to drift. Fix: centralize matching in one selector/service, prefilter in SQL, and
     move ranking to precomputed or queryable fields. Difficulty: Large.