### PR TITLE
Refine listings map browser layout

### DIFF
--- a/listings/tests/test_pages.py
+++ b/listings/tests/test_pages.py
@@ -394,6 +394,7 @@ class ListingPageTests(ListingTestCase):
         self.assertContains(response, "data-listings-page")
         self.assertContains(response, "listing-browser-page")
         self.assertContains(response, "data-listings-workspace")
+        self.assertContains(response, "listing-browser-command-deck")
         self.assertContains(response, "data-listings-filters")
         self.assertContains(response, "data-listings-filter-form")
         self.assertContains(response, "data-listings-filter-menu")
@@ -406,6 +407,7 @@ class ListingPageTests(ListingTestCase):
         self.assertContains(response, "data-listings-map-root")
         self.assertContains(response, "data-listings-map")
         self.assertContains(response, "data-listings-results")
+        self.assertContains(response, "data-listings-results-summary")
         self.assertContains(response, "data-listings-live-error")
         self.assertContains(response, 'class="form-control listing-filter-search-input"')
         self.assertNotContains(response, "Boston College rentals")
@@ -414,10 +416,10 @@ class ListingPageTests(ListingTestCase):
             'class="btn btn-brand" href="/listings/create/">Create listing</a>',
             html=False,
         )
-        self.assertNotContains(response, ">Reset<", html=False)
+        self.assertContains(response, ">Reset<", html=False)
         self.assertLess(browser_index, results_index)
-        self.assertLess(workspace_index, results_index)
-        self.assertLess(results_index, filters_index)
+        self.assertLess(workspace_index, filters_index)
+        self.assertLess(filters_index, results_index)
         self.assertLess(filters_index, map_index)
         self.assertLess(results_index, map_index)
 

--- a/static/css/listings.css
+++ b/static/css/listings.css
@@ -112,34 +112,33 @@
 }
 
 .listing-filter-command-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: clamp(14rem, 19vw, 17rem) minmax(0, 1fr) auto;
     align-items: center;
-    gap: 0.55rem;
-    min-width: 0;
+    gap: 0.45rem;
 }
 
 .listing-filter-search-shell {
-    flex: 1 1 19rem;
-    min-width: 15rem;
+    min-width: 0;
 }
 
 .listing-filter-toolbar-row {
     display: flex;
     flex-wrap: nowrap;
-    gap: 0.45rem;
+    gap: 0.35rem;
     align-items: center;
     min-width: 0;
 }
 
 .listing-filter-toolbar-row-deck {
-    flex: 1 1 auto;
+    width: 100%;
     overflow: visible;
     padding-top: 0;
     border-top: 0;
 }
 
 .listing-filter-search-input {
-    min-height: 2.55rem;
+    min-height: 2.45rem;
     border: 1px solid rgba(var(--gray-700-rgb), 0.14);
     border-radius: 999px;
     background: rgba(var(--white-rgb), 0.96);
@@ -180,9 +179,9 @@
 .listing-filter-trigger {
     display: inline-flex;
     align-items: center;
-    gap: 0.45rem;
-    min-height: 2.4rem;
-    padding: 0.48rem 0.8rem;
+    gap: 0.38rem;
+    min-height: 2.25rem;
+    padding: 0.42rem 0.7rem;
     border: 1px solid rgba(var(--gray-700-rgb), 0.16);
     border-radius: 999px;
     background: rgba(var(--white-rgb), 0.98);
@@ -232,14 +231,14 @@
 
 .listing-filter-trigger-label {
     color: var(--gray-900);
-    font-size: 0.78rem;
+    font-size: 0.75rem;
     font-weight: 700;
     line-height: 1;
 }
 
 .listing-filter-trigger-value {
     color: var(--gray-500);
-    font-size: 0.75rem;
+    font-size: 0.72rem;
     font-weight: 600;
     line-height: 1;
 }
@@ -1969,24 +1968,7 @@
     }
 
     .listing-filter-command-row {
-        flex-wrap: wrap;
-        align-items: stretch;
-    }
-
-    .listing-filter-search-shell {
-        flex-basis: 16rem;
-    }
-
-    .listing-filter-toolbar-row-deck {
-        flex-basis: 100%;
-        order: 3;
-        overflow: visible;
-        flex-wrap: wrap;
-        scrollbar-width: auto;
-    }
-
-    .listing-filter-deck-actions {
-        margin-left: auto;
+        grid-template-columns: 13.5rem minmax(0, 1fr) auto;
     }
 
     .listing-results-pane,
@@ -2061,25 +2043,12 @@
         justify-content: flex-start;
     }
 
-    .listing-filter-deck-actions {
-        margin-left: 0;
-    }
-
     .listing-filter-grid {
         grid-template-columns: minmax(0, 1fr);
     }
 
-    .listing-filter-toolbar-row {
-        gap: 0.5rem;
-    }
-
-    .listing-filter-menu {
-        flex: 1 1 calc(50% - 0.25rem);
-    }
-
-    .listing-filter-trigger {
-        width: 100%;
-        justify-content: space-between;
+    .listing-filter-command-row {
+        grid-template-columns: 12rem minmax(0, 1fr) auto;
     }
 
     .listing-results-pane .listing-card {
@@ -2118,11 +2087,21 @@
     }
 
     .listing-filter-command-row {
+        display: flex;
+        flex-wrap: wrap;
         gap: 0.45rem;
     }
 
     .listing-filter-menu {
         flex-basis: 100%;
+    }
+
+    .listing-filter-toolbar-row {
+        flex-wrap: wrap;
+    }
+
+    .listing-filter-toolbar-row-deck {
+        width: 100%;
     }
 
     .listing-filter-search-input {

--- a/static/css/listings.css
+++ b/static/css/listings.css
@@ -1,6 +1,9 @@
 .listing-reset-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.35rem;
     color: var(--primary-600);
-    font-size: 0.84rem;
+    font-size: 0.8rem;
     font-weight: 700;
     text-decoration: none;
 }
@@ -82,7 +85,7 @@
 
 .listing-browser-command-deck {
     position: relative;
-    padding: 1rem 1.1rem 1.05rem;
+    padding: 0.7rem 0.8rem;
     border: 1px solid rgba(var(--gray-700-rgb), 0.14);
     border-radius: 1rem;
     background:
@@ -100,55 +103,6 @@
     background: linear-gradient(90deg, rgba(var(--primary-rgb), 0.92), rgba(var(--secondary-rgb), 0.55));
 }
 
-.listing-browser-command-head {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 1.2rem;
-    margin-bottom: 0.9rem;
-}
-
-.listing-browser-command-copy {
-    display: grid;
-    gap: 0.15rem;
-    max-width: 46rem;
-}
-
-.listing-browser-command-meta {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 0.45rem;
-}
-
-.listing-browser-kicker,
-.listing-filter-kicker,
-.listing-results-kicker,
-.listing-map-kicker {
-    margin: 0;
-    color: var(--gray-500);
-    font-size: 0.66rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
-.listing-browser-title {
-    margin: 0;
-    color: var(--text-strong);
-    font-size: clamp(1.6rem, 2.2vw, 2.15rem);
-    font-weight: 700;
-    line-height: 1;
-    letter-spacing: -0.04em;
-}
-
-.listing-browser-count {
-    margin: 0.22rem 0 0;
-    color: var(--text-muted);
-    font-size: 0.87rem;
-    line-height: 1.45;
-}
-
 .listing-results-filter-bar {
     position: relative;
     z-index: 6;
@@ -157,29 +111,40 @@
     background: transparent;
 }
 
-.listing-filter-search-row {
-    margin-bottom: 0.65rem;
-}
-
-.listing-filter-search-row-deck {
-    display: grid;
-    grid-template-columns: minmax(0, 1.3fr) auto;
-    gap: 0.8rem;
+.listing-filter-command-row {
+    display: flex;
     align-items: center;
-    margin-bottom: 0.75rem;
-}
-
-.listing-filter-search-shell {
+    gap: 0.55rem;
     min-width: 0;
 }
 
+.listing-filter-search-shell {
+    flex: 1 1 19rem;
+    min-width: 15rem;
+}
+
+.listing-filter-toolbar-row {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0.45rem;
+    align-items: center;
+    min-width: 0;
+}
+
+.listing-filter-toolbar-row-deck {
+    flex: 1 1 auto;
+    overflow: visible;
+    padding-top: 0;
+    border-top: 0;
+}
+
 .listing-filter-search-input {
-    min-height: 3rem;
+    min-height: 2.55rem;
     border: 1px solid rgba(var(--gray-700-rgb), 0.14);
     border-radius: 999px;
     background: rgba(var(--white-rgb), 0.96);
     box-shadow: inset 0 1px 0 rgba(var(--white-rgb), 0.72);
-    padding-inline: 1rem;
+    padding-inline: 0.95rem;
 }
 
 .listing-filter-search-input:focus {
@@ -191,27 +156,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    gap: 0.7rem;
-}
-
-.listing-filter-deck-label {
-    color: var(--gray-500);
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-}
-
-.listing-filter-toolbar-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.55rem;
-    align-items: center;
-}
-
-.listing-filter-toolbar-row-deck {
-    padding-top: 0.8rem;
-    border-top: 1px solid rgba(var(--gray-700-rgb), 0.09);
+    flex: 0 0 auto;
 }
 
 .listing-filter-menu {
@@ -235,9 +180,9 @@
 .listing-filter-trigger {
     display: inline-flex;
     align-items: center;
-    gap: 0.55rem;
-    min-height: 2.72rem;
-    padding: 0.58rem 0.92rem;
+    gap: 0.45rem;
+    min-height: 2.4rem;
+    padding: 0.48rem 0.8rem;
     border: 1px solid rgba(var(--gray-700-rgb), 0.16);
     border-radius: 999px;
     background: rgba(var(--white-rgb), 0.98);
@@ -274,8 +219,8 @@
 
 .listing-filter-trigger::after {
     content: "";
-    width: 0.72rem;
-    height: 0.72rem;
+    width: 0.64rem;
+    height: 0.64rem;
     flex-shrink: 0;
     background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14' fill='none'%3E%3Cpath d='M3.25 5.25L7 9L10.75 5.25' stroke='%23495868' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") center / contain no-repeat;
     transition: transform 140ms ease;
@@ -287,14 +232,14 @@
 
 .listing-filter-trigger-label {
     color: var(--gray-900);
-    font-size: 0.81rem;
+    font-size: 0.78rem;
     font-weight: 700;
     line-height: 1;
 }
 
 .listing-filter-trigger-value {
     color: var(--gray-500);
-    font-size: 0.8rem;
+    font-size: 0.75rem;
     font-weight: 600;
     line-height: 1;
 }
@@ -665,52 +610,36 @@
 .listing-results-pane-head,
 .listing-map-pane-head {
     display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 1rem;
+    align-items: center;
 }
 
 .listing-results-pane-head {
-    padding: 0.95rem 1rem 0.85rem;
+    justify-content: flex-start;
+    padding: 0.75rem 1rem 0.7rem;
     border-bottom: 1px solid rgba(var(--gray-700-rgb), 0.1);
     background: linear-gradient(180deg, rgba(var(--gray-100-rgb), 0.6), rgba(var(--white-rgb), 0.9));
 }
 
-.listing-results-pane-head-actions {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 0.45rem;
-}
-
 .listing-map-pane-head {
     position: absolute;
-    top: 1rem;
-    left: 1rem;
-    right: 1rem;
+    top: 0.9rem;
+    right: 0.9rem;
     z-index: 8;
-    align-items: flex-start;
-    padding: 0.85rem 0.95rem;
+    justify-content: flex-end;
+    padding: 0.35rem;
     border: 1px solid rgba(var(--gray-700-rgb), 0.14);
-    border-radius: 0.9rem;
-    background: rgba(var(--white-rgb), 0.9);
-    box-shadow: 0 16px 28px rgba(var(--gray-900-rgb), 0.1);
-    backdrop-filter: blur(18px);
-    -webkit-backdrop-filter: blur(18px);
+    border-radius: 0.85rem;
+    background: rgba(var(--white-rgb), 0.92);
+    box-shadow: 0 14px 28px rgba(var(--gray-900-rgb), 0.12);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
 }
 
 .listing-map-head-actions {
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    flex-wrap: wrap;
-    gap: 0.7rem;
-}
-
-.listing-map-head-copy {
-    display: grid;
-    gap: 0.12rem;
-    max-width: 28rem;
+    gap: 0.4rem;
 }
 
 .listing-map-style-toggle {
@@ -754,16 +683,9 @@
 }
 
 .listing-results-summary {
-    margin: 0.2rem 0 0;
-    color: var(--text-muted);
-    font-size: 0.84rem;
-    line-height: 1.5;
-}
-
-.listing-map-caption {
     margin: 0;
     color: var(--text-muted);
-    font-size: 0.76rem;
+    font-size: 0.8rem;
     line-height: 1.45;
 }
 
@@ -895,10 +817,6 @@
     justify-content: center;
 }
 
-.listing-map-title {
-    max-width: 26rem;
-}
-
 .listing-map-frame {
     position: relative;
     flex: 1;
@@ -923,33 +841,6 @@
     z-index: 0;
     width: 100%;
     height: 100%;
-}
-
-.listing-map-status-bar {
-    position: absolute;
-    left: 1rem;
-    bottom: 1rem;
-    z-index: 7;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.45rem;
-    max-width: calc(100% - 2rem);
-}
-
-.listing-map-status-pill {
-    display: inline-flex;
-    align-items: center;
-    min-height: 2rem;
-    padding: 0.34rem 0.68rem;
-    border: 1px solid rgba(var(--white-rgb), 0.22);
-    border-radius: 999px;
-    background: rgba(var(--gray-900-rgb), 0.7);
-    color: var(--white);
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.03em;
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
 }
 
 .listing-map-note {
@@ -1021,7 +912,7 @@
 }
 
 .maplibregl-ctrl-top-right {
-    top: 5.9rem;
+    top: 4.75rem;
     right: 1rem;
 }
 
@@ -2077,17 +1968,25 @@
         grid-template-columns: minmax(0, 1fr);
     }
 
-    .listing-browser-command-head {
-        align-items: flex-start;
-        flex-direction: column;
+    .listing-filter-command-row {
+        flex-wrap: wrap;
+        align-items: stretch;
     }
 
-    .listing-browser-command-meta {
-        justify-content: flex-start;
+    .listing-filter-search-shell {
+        flex-basis: 16rem;
     }
 
-    .listing-filter-search-row-deck {
-        grid-template-columns: minmax(0, 1fr);
+    .listing-filter-toolbar-row-deck {
+        flex-basis: 100%;
+        order: 3;
+        overflow: visible;
+        flex-wrap: wrap;
+        scrollbar-width: auto;
+    }
+
+    .listing-filter-deck-actions {
+        margin-left: auto;
     }
 
     .listing-results-pane,
@@ -2148,7 +2047,7 @@
     }
 
     .listing-browser-command-deck {
-        padding: 0.95rem 1rem 1rem;
+        padding: 0.7rem 0.75rem;
     }
 
     .listing-results-pane-head,
@@ -2162,12 +2061,8 @@
         justify-content: flex-start;
     }
 
-    .listing-results-pane-head-actions {
-        justify-content: flex-start;
-    }
-
     .listing-filter-deck-actions {
-        justify-content: space-between;
+        margin-left: 0;
     }
 
     .listing-filter-grid {
@@ -2176,10 +2071,6 @@
 
     .listing-filter-toolbar-row {
         gap: 0.5rem;
-    }
-
-    .listing-filter-search-row {
-        margin-bottom: 0.55rem;
     }
 
     .listing-filter-menu {
@@ -2223,7 +2114,11 @@
 
 @media (max-width: 767px) {
     .listing-browser-command-deck {
-        padding: 0.85rem 0.9rem 0.95rem;
+        padding: 0.65rem 0.7rem;
+    }
+
+    .listing-filter-command-row {
+        gap: 0.45rem;
     }
 
     .listing-filter-menu {
@@ -2254,27 +2149,19 @@
 
     .listing-map-pane-head {
         top: 0.75rem;
-        left: 0.75rem;
         right: 0.75rem;
-        padding: 0.75rem 0.8rem;
+        padding: 0.3rem;
     }
 
-    .listing-map-status-bar {
+    .listing-map-note {
         left: 0.75rem;
         right: 0.75rem;
         bottom: 0.75rem;
         max-width: none;
     }
 
-    .listing-map-note {
-        left: 0.75rem;
-        right: 0.75rem;
-        bottom: 3.5rem;
-        max-width: none;
-    }
-
     .maplibregl-ctrl-top-right {
-        top: 7.1rem;
+        top: 4.5rem;
         right: 0.75rem;
     }
 

--- a/static/css/listings.css
+++ b/static/css/listings.css
@@ -622,9 +622,12 @@
 .listing-map-pane-head {
     position: absolute;
     top: 0.9rem;
-    right: 0.9rem;
+    left: 0.9rem;
     z-index: 8;
-    justify-content: flex-end;
+    display: inline-flex;
+    width: max-content;
+    max-width: calc(100% - 1.8rem);
+    justify-content: flex-start;
     padding: 0.35rem;
     border: 1px solid rgba(var(--gray-700-rgb), 0.14);
     border-radius: 0.85rem;
@@ -637,7 +640,7 @@
 .listing-map-head-actions {
     display: flex;
     align-items: center;
-    justify-content: flex-end;
+    justify-content: flex-start;
     gap: 0.4rem;
 }
 
@@ -2128,7 +2131,7 @@
 
     .listing-map-pane-head {
         top: 0.75rem;
-        right: 0.75rem;
+        left: 0.75rem;
         padding: 0.3rem;
     }
 

--- a/static/css/listings.css
+++ b/static/css/listings.css
@@ -10,10 +10,25 @@
 }
 
 .listing-browser-body {
-    background: var(--page-background);
+    background:
+        radial-gradient(circle at top right, rgba(var(--secondary-rgb), 0.12), transparent 30rem),
+        radial-gradient(circle at top left, rgba(var(--primary-rgb), 0.08), transparent 24rem),
+        var(--page-background);
+    overflow: hidden;
+}
+
+.listing-browser-body .site-shell {
+    height: 100dvh;
+    overflow: hidden;
+}
+
+.listing-browser-body .site-footer {
+    display: none;
 }
 
 .listing-browser-body .page-wrap {
+    display: flex;
+    flex: 1 1 auto;
     min-height: 0;
     padding-bottom: 0;
     overflow: hidden;
@@ -24,13 +39,16 @@
     margin-inline: auto;
     display: flex;
     flex-direction: column;
-    gap: 0.85rem;
-    height: calc(100dvh - 4.5rem);
-    padding: 0.85rem 0 1.25rem;
+    gap: 0.9rem;
+    height: 100%;
+    min-height: 0;
+    padding: 0.7rem 0 0.8rem;
 }
 
 .listing-browser-shell {
-    display: contents;
+    display: flex;
+    flex: 1;
+    min-height: 0;
 }
 
 .listing-results-pane,
@@ -38,27 +56,69 @@
     min-width: 0;
     min-height: 0;
     border: 1px solid rgba(var(--gray-700-rgb), 0.14);
-    border-radius: var(--radius-lg);
-    background: rgba(var(--white-rgb), 0.98);
-    box-shadow: var(--shadow-sm);
+    border-radius: 1rem;
+    background: rgba(var(--white-rgb), 0.94);
+    box-shadow: 0 18px 34px rgba(var(--gray-900-rgb), 0.08);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
 }
 
 .listing-browser-workspace {
     display: flex;
     flex: 1;
     flex-direction: column;
-    height: 100%;
+    gap: 0.9rem;
     min-height: 0;
 }
 
 .listing-browser-main {
     display: grid;
-    grid-template-columns: minmax(21.5rem, 29rem) minmax(0, 1fr);
-    gap: 0.85rem;
+    grid-template-columns: minmax(25rem, 31rem) minmax(0, 1fr);
+    gap: 0.9rem;
     flex: 1;
     min-height: 0;
-    height: 100%;
     align-items: stretch;
+}
+
+.listing-browser-command-deck {
+    position: relative;
+    padding: 1rem 1.1rem 1.05rem;
+    border: 1px solid rgba(var(--gray-700-rgb), 0.14);
+    border-radius: 1rem;
+    background:
+        linear-gradient(135deg, rgba(var(--white-rgb), 0.98), rgba(var(--secondary-rgb), 0.05)),
+        rgba(var(--white-rgb), 0.96);
+    box-shadow: 0 16px 28px rgba(var(--gray-900-rgb), 0.06);
+}
+
+.listing-browser-command-deck::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto auto 0;
+    width: 100%;
+    height: 3px;
+    background: linear-gradient(90deg, rgba(var(--primary-rgb), 0.92), rgba(var(--secondary-rgb), 0.55));
+}
+
+.listing-browser-command-head {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1.2rem;
+    margin-bottom: 0.9rem;
+}
+
+.listing-browser-command-copy {
+    display: grid;
+    gap: 0.15rem;
+    max-width: 46rem;
+}
+
+.listing-browser-command-meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.45rem;
 }
 
 .listing-browser-kicker,
@@ -76,35 +136,70 @@
 .listing-browser-title {
     margin: 0;
     color: var(--text-strong);
-    font-size: clamp(1.45rem, 2vw, 1.9rem);
+    font-size: clamp(1.6rem, 2.2vw, 2.15rem);
     font-weight: 700;
     line-height: 1;
     letter-spacing: -0.04em;
 }
 
 .listing-browser-count {
-    margin: 0.18rem 0 0;
+    margin: 0.22rem 0 0;
     color: var(--text-muted);
-    font-size: 0.86rem;
+    font-size: 0.87rem;
     line-height: 1.45;
 }
 
 .listing-results-filter-bar {
     position: relative;
     z-index: 6;
-    padding: 0.72rem 0.95rem;
-    border-bottom: 1px solid rgba(var(--gray-700-rgb), 0.1);
-    background: rgba(var(--white-rgb), 0.98);
+    padding: 0;
+    border: 0;
+    background: transparent;
 }
 
 .listing-filter-search-row {
     margin-bottom: 0.65rem;
 }
 
+.listing-filter-search-row-deck {
+    display: grid;
+    grid-template-columns: minmax(0, 1.3fr) auto;
+    gap: 0.8rem;
+    align-items: center;
+    margin-bottom: 0.75rem;
+}
+
+.listing-filter-search-shell {
+    min-width: 0;
+}
+
 .listing-filter-search-input {
-    min-height: 2.72rem;
+    min-height: 3rem;
+    border: 1px solid rgba(var(--gray-700-rgb), 0.14);
     border-radius: 999px;
-    padding-inline: 0.95rem;
+    background: rgba(var(--white-rgb), 0.96);
+    box-shadow: inset 0 1px 0 rgba(var(--white-rgb), 0.72);
+    padding-inline: 1rem;
+}
+
+.listing-filter-search-input:focus {
+    border-color: rgba(var(--secondary-rgb), 0.26);
+    box-shadow: 0 0 0 3px rgba(var(--secondary-rgb), 0.12);
+}
+
+.listing-filter-deck-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.7rem;
+}
+
+.listing-filter-deck-label {
+    color: var(--gray-500);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
 }
 
 .listing-filter-toolbar-row {
@@ -114,8 +209,9 @@
     align-items: center;
 }
 
-.listing-filter-toolbar-row-results {
-    justify-content: flex-start;
+.listing-filter-toolbar-row-deck {
+    padding-top: 0.8rem;
+    border-top: 1px solid rgba(var(--gray-700-rgb), 0.09);
 }
 
 .listing-filter-menu {
@@ -212,12 +308,14 @@
     top: calc(100% + 0.45rem);
     left: 0;
     z-index: 20;
-    width: min(21rem, calc(100vw - 2rem));
+    width: min(21.5rem, calc(100vw - 2rem));
     padding: 0.95rem;
     border: 1px solid rgba(var(--gray-700-rgb), 0.14);
     border-radius: var(--radius-lg);
-    background: rgba(var(--white-rgb), 0.99);
-    box-shadow: var(--shadow-md);
+    background: rgba(var(--white-rgb), 0.995);
+    box-shadow: 0 16px 28px rgba(var(--gray-900-rgb), 0.1);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
 }
 
 .listing-filter-menu.is-align-right .listing-filter-popover {
@@ -555,7 +653,7 @@
 .listing-results-pane {
     position: relative;
     z-index: 3;
-    overflow: visible;
+    overflow: hidden;
 }
 
 .listing-map-pane {
@@ -564,13 +662,41 @@
     overflow: hidden;
 }
 
+.listing-results-pane-head,
 .listing-map-pane-head {
     display: flex;
     align-items: flex-end;
     justify-content: space-between;
     gap: 1rem;
-    padding: 0.8rem 0.95rem;
+}
+
+.listing-results-pane-head {
+    padding: 0.95rem 1rem 0.85rem;
     border-bottom: 1px solid rgba(var(--gray-700-rgb), 0.1);
+    background: linear-gradient(180deg, rgba(var(--gray-100-rgb), 0.6), rgba(var(--white-rgb), 0.9));
+}
+
+.listing-results-pane-head-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.45rem;
+}
+
+.listing-map-pane-head {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    right: 1rem;
+    z-index: 8;
+    align-items: flex-start;
+    padding: 0.85rem 0.95rem;
+    border: 1px solid rgba(var(--gray-700-rgb), 0.14);
+    border-radius: 0.9rem;
+    background: rgba(var(--white-rgb), 0.9);
+    box-shadow: 0 16px 28px rgba(var(--gray-900-rgb), 0.1);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
 }
 
 .listing-map-head-actions {
@@ -579,6 +705,12 @@
     justify-content: flex-end;
     flex-wrap: wrap;
     gap: 0.7rem;
+}
+
+.listing-map-head-copy {
+    display: grid;
+    gap: 0.12rem;
+    max-width: 28rem;
 }
 
 .listing-map-style-toggle {
@@ -628,18 +760,25 @@
     line-height: 1.5;
 }
 
+.listing-map-caption {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.76rem;
+    line-height: 1.45;
+}
+
 .listing-results-alert,
 .listing-live-error {
-    margin: 0.8rem 0.95rem 0;
+    margin: 0.8rem 1rem 0;
 }
 
 .listing-results-scroll {
     display: flex;
     flex: 1;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.85rem;
     min-height: 0;
-    padding: 0.75rem;
+    padding: 0.9rem 1rem 1rem;
     overflow-y: auto;
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
@@ -666,17 +805,43 @@
     grid-template-columns: minmax(0, 1fr);
 }
 
+.listing-results-pane .listing-card {
+    display: grid;
+    grid-template-columns: minmax(11.5rem, 12.5rem) minmax(0, 1fr);
+    min-height: 12rem;
+    border-color: rgba(var(--gray-700-rgb), 0.12);
+    border-radius: 0.9rem;
+    background: linear-gradient(180deg, rgba(var(--white-rgb), 1), rgba(var(--gray-100-rgb), 0.22));
+    box-shadow: 0 10px 24px rgba(var(--gray-900-rgb), 0.05);
+}
+
+.listing-results-pane .listing-card:hover {
+    transform: translateY(-2px);
+    border-color: rgba(var(--secondary-rgb), 0.24);
+    box-shadow: 0 18px 36px rgba(var(--gray-900-rgb), 0.08);
+}
+
+.listing-results-pane .listing-card[data-listing-selected="true"] {
+    border-color: rgba(var(--primary-rgb), 0.4);
+    box-shadow:
+        0 0 0 3px rgba(var(--primary-rgb), 0.08),
+        0 18px 36px rgba(var(--gray-900-rgb), 0.08);
+}
+
 .listing-results-pane .listing-card-media {
-    aspect-ratio: 16 / 6.6;
+    aspect-ratio: auto;
+    height: 100%;
+    min-height: 100%;
+    border-right: 1px solid rgba(var(--gray-700-rgb), 0.08);
 }
 
 .listing-results-pane .listing-card-body {
-    gap: 0.24rem;
-    padding: 0.64rem 0.72rem 0.68rem;
+    gap: 0.35rem;
+    padding: 0.82rem 0.95rem 0.9rem;
 }
 
 .listing-results-pane .listing-card-badges {
-    gap: 0.22rem;
+    gap: 0.28rem;
 }
 
 .listing-results-pane .listing-card-badge,
@@ -688,29 +853,35 @@
 }
 
 .listing-results-pane .listing-card-price {
-    font-size: 0.96rem;
+    font-size: 1rem;
 }
 
 .listing-results-pane .listing-card-title {
-    font-size: 0.88rem;
+    font-size: 0.94rem;
 }
 
 .listing-results-pane .listing-card-address,
 .listing-results-pane .listing-card-specs,
 .listing-results-pane .listing-card-summary {
-    font-size: 0.73rem;
+    font-size: 0.76rem;
 }
 
 .listing-results-pane .listing-card-summary {
-    -webkit-line-clamp: 1;
+    -webkit-line-clamp: 2;
 }
 
 .listing-results-pane .listing-card-rating {
-    font-size: 0.7rem;
+    font-size: 0.73rem;
 }
 
 .listing-results-pane .listing-card-owner {
-    padding-top: 0.52rem;
+    margin-top: auto;
+    padding-top: 0.65rem;
+}
+
+.listing-results-pane .listing-favorite-form {
+    top: 0.75rem;
+    right: 0.75rem;
 }
 
 .listing-results-empty {
@@ -733,20 +904,68 @@
     flex: 1;
     min-height: 0;
     overflow: hidden;
-    background: #d7dee5;
+    background:
+        linear-gradient(180deg, rgba(12, 20, 31, 0.08), rgba(12, 20, 31, 0.14)),
+        #d7dee5;
+}
+
+.listing-map-frame::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    background: linear-gradient(180deg, rgba(12, 20, 31, 0.1), rgba(12, 20, 31, 0) 26%, rgba(12, 20, 31, 0.12));
 }
 
 .listing-map {
+    position: relative;
+    z-index: 0;
     width: 100%;
     height: 100%;
 }
 
+.listing-map-status-bar {
+    position: absolute;
+    left: 1rem;
+    bottom: 1rem;
+    z-index: 7;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    max-width: calc(100% - 2rem);
+}
+
+.listing-map-status-pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    padding: 0.34rem 0.68rem;
+    border: 1px solid rgba(var(--white-rgb), 0.22);
+    border-radius: 999px;
+    background: rgba(var(--gray-900-rgb), 0.7);
+    color: var(--white);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+}
+
 .listing-map-note {
-    margin: 0.8rem 0.95rem 0.95rem;
+    position: absolute;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 8;
+    max-width: 20rem;
+    margin: 0;
     padding: 0.8rem 0.9rem;
     border: 1px solid rgba(var(--gray-700-rgb), 0.12);
-    border-radius: var(--radius-md);
-    background: rgba(var(--white-rgb), 0.82);
+    border-radius: 0.85rem;
+    background: rgba(var(--white-rgb), 0.9);
+    box-shadow: 0 14px 28px rgba(var(--gray-900-rgb), 0.1);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
 }
 
 .listing-map-note-title {
@@ -767,20 +986,22 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 3rem;
-    min-height: 1.95rem;
-    padding: 0.3rem 0.65rem;
-    border: 1px solid rgba(var(--gray-900-rgb), 0.12);
+    min-width: 3.15rem;
+    min-height: 2.05rem;
+    padding: 0.34rem 0.72rem;
+    border: 1px solid rgba(var(--gray-900-rgb), 0.1);
     border-radius: 999px;
-    background: rgba(var(--white-rgb), 0.98);
+    background: rgba(var(--white-rgb), 0.97);
     color: var(--gray-900);
-    box-shadow: 0 4px 12px rgba(var(--gray-900-rgb), 0.1);
+    box-shadow: 0 10px 22px rgba(var(--gray-900-rgb), 0.14);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     cursor: pointer;
     transition: transform 140ms ease, border-color 140ms ease, background-color 140ms ease, color 140ms ease;
 }
 
 .listing-map-marker:hover {
-    transform: translateY(-1px);
+    transform: translateY(-2px);
     border-color: rgba(var(--primary-rgb), 0.28);
 }
 
@@ -788,18 +1009,20 @@
     border-color: rgba(var(--primary-rgb), 0.92);
     background: var(--primary-600);
     color: var(--white);
+    box-shadow: 0 14px 28px rgba(var(--primary-rgb), 0.22);
 }
 
 .listing-map-marker-label {
-    font-size: 0.78rem;
+    font-size: 0.8rem;
     font-weight: 800;
+    font-variant-numeric: tabular-nums;
     line-height: 1;
     white-space: nowrap;
 }
 
 .maplibregl-ctrl-top-right {
-    top: 0.9rem;
-    right: 0.9rem;
+    top: 5.9rem;
+    right: 1rem;
 }
 
 .maplibregl-ctrl-group {
@@ -1826,7 +2049,17 @@
 }
 
 @media (max-width: 1199px) {
+    .listing-browser-body {
+        overflow: auto;
+    }
+
+    .listing-browser-body .site-shell {
+        height: auto;
+        overflow: visible;
+    }
+
     .listing-browser-body .page-wrap {
+        display: block;
         overflow: visible;
     }
 
@@ -1838,6 +2071,22 @@
     .listing-browser-workspace,
     .listing-browser-main {
         height: auto;
+    }
+
+    .listing-browser-main {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .listing-browser-command-head {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .listing-browser-command-meta {
+        justify-content: flex-start;
+    }
+
+    .listing-filter-search-row-deck {
         grid-template-columns: minmax(0, 1fr);
     }
 
@@ -1852,7 +2101,7 @@
     }
 
     .listing-map-pane {
-        min-height: 32rem;
+        min-height: 34rem;
     }
 
     .listing-results-scroll {
@@ -1898,6 +2147,10 @@
         padding: 0.85rem 0.9rem 1rem;
     }
 
+    .listing-browser-command-deck {
+        padding: 0.95rem 1rem 1rem;
+    }
+
     .listing-results-pane-head,
     .listing-map-pane-head,
     .listing-detail-panel-head {
@@ -1911,6 +2164,10 @@
 
     .listing-results-pane-head-actions {
         justify-content: flex-start;
+    }
+
+    .listing-filter-deck-actions {
+        justify-content: space-between;
     }
 
     .listing-filter-grid {
@@ -1934,6 +2191,17 @@
         justify-content: space-between;
     }
 
+    .listing-results-pane .listing-card {
+        grid-template-columns: minmax(0, 1fr);
+        min-height: auto;
+    }
+
+    .listing-results-pane .listing-card-media {
+        aspect-ratio: 16 / 9.2;
+        border-right: 0;
+        border-bottom: 1px solid rgba(var(--gray-700-rgb), 0.08);
+    }
+
     .listing-detail-price-block {
         justify-items: start;
         text-align: left;
@@ -1954,12 +2222,16 @@
 }
 
 @media (max-width: 767px) {
+    .listing-browser-command-deck {
+        padding: 0.85rem 0.9rem 0.95rem;
+    }
+
     .listing-filter-menu {
         flex-basis: 100%;
     }
 
     .listing-filter-search-input {
-        min-height: 2.55rem;
+        min-height: 2.65rem;
     }
 
     .listing-filter-popover,
@@ -1974,6 +2246,36 @@
     .listing-filter-date-grid,
     .listing-filter-checkbox-grid {
         grid-template-columns: 1fr;
+    }
+
+    .listing-map-pane {
+        min-height: 28rem;
+    }
+
+    .listing-map-pane-head {
+        top: 0.75rem;
+        left: 0.75rem;
+        right: 0.75rem;
+        padding: 0.75rem 0.8rem;
+    }
+
+    .listing-map-status-bar {
+        left: 0.75rem;
+        right: 0.75rem;
+        bottom: 0.75rem;
+        max-width: none;
+    }
+
+    .listing-map-note {
+        left: 0.75rem;
+        right: 0.75rem;
+        bottom: 3.5rem;
+        max-width: none;
+    }
+
+    .maplibregl-ctrl-top-right {
+        top: 7.1rem;
+        right: 0.75rem;
     }
 
     .listing-card {

--- a/templates/listings/listing_list.html
+++ b/templates/listings/listing_list.html
@@ -40,16 +40,53 @@
             </form>
             <section class="listing-browser-shell" data-listings-browser-shell>
                 <section class="listing-browser-workspace" data-listings-workspace>
-                    <div class="listing-browser-main">
-                        <aside class="listing-results-pane" data-listings-results data-listings-results-pane>
-                            <form
-                                class="listing-results-filter-bar"
-                                method="get"
-                                action="{% url 'listings:listing_list' %}"
-                                data-listings-filters
-                                data-listings-filter-form
-                            >
-                                <div class="listing-filter-search-row">
+                    <section class="listing-browser-command-deck">
+                        <div class="listing-browser-command-head">
+                            <div class="listing-browser-command-copy">
+                                <p class="listing-browser-kicker">
+                                    {% if has_listing_only_access %}Inventory map{% else %}Live market map{% endif %}
+                                </p>
+                                <h1 class="listing-browser-title">
+                                    {% if has_listing_only_access %}
+                                        Operate your listings from a fixed command deck.
+                                    {% else %}
+                                        Operate the market from a map-first workspace.
+                                    {% endif %}
+                                </h1>
+                                <p class="listing-browser-count">
+                                    {% if has_listing_only_access %}
+                                        The map stays pinned while the rail and controls update around your active inventory.
+                                    {% else %}
+                                        Horizontal controls keep search open, the listing rail scrolls independently, and the map stays locked in view.
+                                    {% endif %}
+                                </p>
+                            </div>
+                            <div class="listing-browser-command-meta">
+                                <span class="app-meta-chip app-meta-chip-primary">
+                                    {{ listings_total }} {% if has_listing_only_access %}owned{% else %}active{% endif %}
+                                </span>
+                                <span class="app-meta-chip app-meta-chip-secondary">
+                                    {% if active_filters.q or active_filters.min_bedrooms or active_filters.min_bathrooms or active_filters.min_price or active_filters.max_price or active_filters.lease_type or active_filters.max_distance or active_filters.availability_start or active_filters.availability_end or active_filters.has_parking or active_filters.is_furnished or active_filters.allows_pets or active_filters.has_yard or active_filters.saved %}
+                                        Filters active
+                                    {% elif has_listing_only_access %}
+                                        Inventory workspace
+                                    {% else %}
+                                        Map-first browsing
+                                    {% endif %}
+                                </span>
+                                <span class="app-meta-chip app-meta-chip-neutral">Drag map to refresh results</span>
+                            </div>
+                        </div>
+
+                        <form
+                            class="listing-results-filter-bar listing-results-filter-deck"
+                            method="get"
+                            action="{% url 'listings:listing_list' %}"
+                            data-listings-filters
+                            data-listings-filter-form
+                        >
+                            <div class="listing-filter-search-row listing-filter-search-row-deck">
+                                <div class="listing-filter-search-shell">
                                     <label class="visually-hidden" for="filter-query">Search listings</label>
                                     <input
                                         class="form-control listing-filter-search-input"
@@ -60,210 +97,236 @@
                                         placeholder="Search by address, neighborhood, or title"
                                     >
                                 </div>
-                                <div class="listing-filter-toolbar-row listing-filter-toolbar-row-results">
-                                    <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="lease">
-                                        <summary class="listing-filter-trigger">
-                                            <span class="listing-filter-trigger-label">Type</span>
-                                            <span class="listing-filter-trigger-value" data-listings-filter-summary="lease">Any type</span>
-                                        </summary>
-                                        <div class="listing-filter-popover">
-                                            <div class="listing-filter-menu-head">
-                                                <h3 class="listing-filter-menu-title">Lease type</h3>
-                                                <p class="listing-filter-menu-copy">Sublease or full lease</p>
-                                            </div>
-                                            <label class="form-label" for="filter-lease">Lease type</label>
-                                            <select class="form-select" id="filter-lease" name="lease_type">
-                                                <option value="">Any type</option>
-                                                {% for value, label in lease_type_filters %}
-                                                    <option value="{{ value }}"{% if active_filters.lease_type == value %} selected{% endif %}>
-                                                        {{ label }}
-                                                    </option>
-                                                {% endfor %}
-                                            </select>
-                                        </div>
-                                    </details>
-
-                                    <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="beds">
-                                        <summary class="listing-filter-trigger">
-                                            <span class="listing-filter-trigger-label">Beds</span>
-                                            <span class="listing-filter-trigger-value" data-listings-filter-summary="beds">Any beds</span>
-                                        </summary>
-                                        <div class="listing-filter-popover">
-                                            <div class="listing-filter-menu-head">
-                                                <h3 class="listing-filter-menu-title">Bedrooms</h3>
-                                                <p class="listing-filter-menu-copy">Minimum bedrooms</p>
-                                            </div>
-                                            <label class="form-label" for="filter-min-bedrooms">Minimum bedrooms</label>
-                                            <select class="form-select" id="filter-min-bedrooms" name="min_bedrooms">
-                                                <option value="">Any beds</option>
-                                                <option value="1"{% if active_filters.min_bedrooms == "1" %} selected{% endif %}>1+ beds</option>
-                                                <option value="2"{% if active_filters.min_bedrooms == "2" %} selected{% endif %}>2+ beds</option>
-                                                <option value="3"{% if active_filters.min_bedrooms == "3" %} selected{% endif %}>3+ beds</option>
-                                                <option value="4"{% if active_filters.min_bedrooms == "4" %} selected{% endif %}>4+ beds</option>
-                                                <option value="5"{% if active_filters.min_bedrooms == "5" %} selected{% endif %}>5+ beds</option>
-                                            </select>
-                                        </div>
-                                    </details>
-
-                                    <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="baths">
-                                        <summary class="listing-filter-trigger">
-                                            <span class="listing-filter-trigger-label">Baths</span>
-                                            <span class="listing-filter-trigger-value" data-listings-filter-summary="baths">Any baths</span>
-                                        </summary>
-                                        <div class="listing-filter-popover">
-                                            <div class="listing-filter-menu-head">
-                                                <h3 class="listing-filter-menu-title">Bathrooms</h3>
-                                                <p class="listing-filter-menu-copy">Minimum bathrooms</p>
-                                            </div>
-                                            <label class="form-label" for="filter-min-bathrooms">Minimum bathrooms</label>
-                                            <select class="form-select" id="filter-min-bathrooms" name="min_bathrooms">
-                                                <option value="">Any baths</option>
-                                                <option value="1"{% if active_filters.min_bathrooms == "1" %} selected{% endif %}>1+ baths</option>
-                                                <option value="1.5"{% if active_filters.min_bathrooms == "1.5" %} selected{% endif %}>1.5+ baths</option>
-                                                <option value="2"{% if active_filters.min_bathrooms == "2" %} selected{% endif %}>2+ baths</option>
-                                                <option value="2.5"{% if active_filters.min_bathrooms == "2.5" %} selected{% endif %}>2.5+ baths</option>
-                                                <option value="3"{% if active_filters.min_bathrooms == "3" %} selected{% endif %}>3+ baths</option>
-                                            </select>
-                                        </div>
-                                    </details>
-
-                                    <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="price">
-                                        <summary class="listing-filter-trigger">
-                                            <span class="listing-filter-trigger-label">Price</span>
-                                            <span class="listing-filter-trigger-value" data-listings-filter-summary="price">Any price</span>
-                                        </summary>
-                                        <div class="listing-filter-popover">
-                                            <div class="listing-filter-menu-head">
-                                                <h3 class="listing-filter-menu-title">Price</h3>
-                                                <p class="listing-filter-menu-copy">Monthly rent</p>
-                                            </div>
-                                            <div class="listing-filter-select-grid">
-                                                <div>
-                                                    <label class="form-label" for="filter-min-price">Minimum</label>
-                                                    <select class="form-select" id="filter-min-price" name="min_price">
-                                                        <option value="">No min</option>
-                                                        <option value="750"{% if active_filters.min_price == "750" %} selected{% endif %}>$750+</option>
-                                                        <option value="1000"{% if active_filters.min_price == "1000" %} selected{% endif %}>$1,000+</option>
-                                                        <option value="1250"{% if active_filters.min_price == "1250" %} selected{% endif %}>$1,250+</option>
-                                                        <option value="1500"{% if active_filters.min_price == "1500" %} selected{% endif %}>$1,500+</option>
-                                                        <option value="2000"{% if active_filters.min_price == "2000" %} selected{% endif %}>$2,000+</option>
-                                                        <option value="2500"{% if active_filters.min_price == "2500" %} selected{% endif %}>$2,500+</option>
-                                                        <option value="3000"{% if active_filters.min_price == "3000" %} selected{% endif %}>$3,000+</option>
-                                                    </select>
-                                                </div>
-                                                <div>
-                                                    <label class="form-label" for="filter-max-price">Maximum</label>
-                                                    <select class="form-select" id="filter-max-price" name="max_price">
-                                                        <option value="">No max</option>
-                                                        <option value="1000"{% if active_filters.max_price == "1000" %} selected{% endif %}>Up to $1,000</option>
-                                                        <option value="1250"{% if active_filters.max_price == "1250" %} selected{% endif %}>Up to $1,250</option>
-                                                        <option value="1500"{% if active_filters.max_price == "1500" %} selected{% endif %}>Up to $1,500</option>
-                                                        <option value="2000"{% if active_filters.max_price == "2000" %} selected{% endif %}>Up to $2,000</option>
-                                                        <option value="2500"{% if active_filters.max_price == "2500" %} selected{% endif %}>Up to $2,500</option>
-                                                        <option value="3000"{% if active_filters.max_price == "3000" %} selected{% endif %}>Up to $3,000</option>
-                                                        <option value="4000"{% if active_filters.max_price == "4000" %} selected{% endif %}>Up to $4,000</option>
-                                                    </select>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </details>
-
-                                    <details class="listing-filter-menu is-align-right" data-listings-filter-menu data-filter-name="filters">
-                                        <summary class="listing-filter-trigger">
-                                            <span class="listing-filter-trigger-label">Filters</span>
-                                            <span class="listing-filter-trigger-value" data-listings-filter-summary="filters">More</span>
-                                        </summary>
-                                        <div class="listing-filter-popover">
-                                            <div class="listing-filter-menu-head">
-                                                <h3 class="listing-filter-menu-title">More filters</h3>
-                                                <p class="listing-filter-menu-copy">Search, distance, dates, saved, and features</p>
-                                            </div>
-
-                                            <div class="listing-filter-stack">
-                                                <div>
-                                                    <label class="form-label" for="filter-max-distance">Distance from campus</label>
-                                                    <select class="form-select" id="filter-max-distance" name="max_distance">
-                                                        <option value="">Any distance</option>
-                                                        <option value="0.5"{% if active_filters.max_distance == "0.5" %} selected{% endif %}>Within 0.5 mi</option>
-                                                        <option value="1"{% if active_filters.max_distance == "1" %} selected{% endif %}>Within 1 mi</option>
-                                                        <option value="1.5"{% if active_filters.max_distance == "1.5" %} selected{% endif %}>Within 1.5 mi</option>
-                                                        <option value="2"{% if active_filters.max_distance == "2" %} selected{% endif %}>Within 2 mi</option>
-                                                        <option value="3"{% if active_filters.max_distance == "3" %} selected{% endif %}>Within 3 mi</option>
-                                                        <option value="5"{% if active_filters.max_distance == "5" %} selected{% endif %}>Within 5 mi</option>
-                                                    </select>
-                                                </div>
-                                                <div class="listing-filter-date-grid">
-                                                    <div>
-                                                        <label class="form-label" for="filter-availability-start">Move-in after</label>
-                                                        <input
-                                                            class="form-control"
-                                                            id="filter-availability-start"
-                                                            type="date"
-                                                            name="availability_start"
-                                                            value="{{ active_filters.availability_start }}"
-                                                        >
-                                                    </div>
-                                                    <div>
-                                                        <label class="form-label" for="filter-availability-end">Move-out before</label>
-                                                        <input
-                                                            class="form-control"
-                                                            id="filter-availability-end"
-                                                            type="date"
-                                                            name="availability_end"
-                                                            value="{{ active_filters.availability_end }}"
-                                                        >
-                                                    </div>
-                                                </div>
-                                                <div>
-                                                    <label class="form-label" for="filter-saved">Saved listings</label>
-                                                    <select class="form-select" id="filter-saved" name="saved">
-                                                        <option value="">All listings</option>
-                                                        <option value="1"{% if active_filters.saved %} selected{% endif %}>Saved only</option>
-                                                    </select>
-                                                </div>
-                                                <div class="listing-filter-checkbox-grid">
-                                                    <label class="listing-filter-checkbox-card">
-                                                        <input
-                                                            type="checkbox"
-                                                            name="has_parking"
-                                                            value="1"
-                                                            {% if active_filters.has_parking %}checked{% endif %}
-                                                        >
-                                                        <span>Parking</span>
-                                                    </label>
-                                                    <label class="listing-filter-checkbox-card">
-                                                        <input
-                                                            type="checkbox"
-                                                            name="is_furnished"
-                                                            value="1"
-                                                            {% if active_filters.is_furnished %}checked{% endif %}
-                                                        >
-                                                        <span>Furnished</span>
-                                                    </label>
-                                                    <label class="listing-filter-checkbox-card">
-                                                        <input
-                                                            type="checkbox"
-                                                            name="allows_pets"
-                                                            value="1"
-                                                            {% if active_filters.allows_pets %}checked{% endif %}
-                                                        >
-                                                        <span>Pets</span>
-                                                    </label>
-                                                    <label class="listing-filter-checkbox-card">
-                                                        <input
-                                                            type="checkbox"
-                                                            name="has_yard"
-                                                            value="1"
-                                                            {% if active_filters.has_yard %}checked{% endif %}
-                                                        >
-                                                        <span>Yard</span>
-                                                    </label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </details>
+                                <div class="listing-filter-deck-actions">
+                                    <span class="listing-filter-deck-label">Command deck</span>
+                                    <a class="listing-reset-link" href="{% url 'listings:listing_list' %}">Reset</a>
                                 </div>
-                            </form>
+                            </div>
+                            <div class="listing-filter-toolbar-row listing-filter-toolbar-row-deck">
+                                <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="lease">
+                                    <summary class="listing-filter-trigger">
+                                        <span class="listing-filter-trigger-label">Type</span>
+                                        <span class="listing-filter-trigger-value" data-listings-filter-summary="lease">Any type</span>
+                                    </summary>
+                                    <div class="listing-filter-popover">
+                                        <div class="listing-filter-menu-head">
+                                            <h3 class="listing-filter-menu-title">Lease type</h3>
+                                            <p class="listing-filter-menu-copy">Sublease or full lease</p>
+                                        </div>
+                                        <label class="form-label" for="filter-lease">Lease type</label>
+                                        <select class="form-select" id="filter-lease" name="lease_type">
+                                            <option value="">Any type</option>
+                                            {% for value, label in lease_type_filters %}
+                                                <option value="{{ value }}"{% if active_filters.lease_type == value %} selected{% endif %}>
+                                                    {{ label }}
+                                                </option>
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                </details>
+
+                                <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="beds">
+                                    <summary class="listing-filter-trigger">
+                                        <span class="listing-filter-trigger-label">Beds</span>
+                                        <span class="listing-filter-trigger-value" data-listings-filter-summary="beds">Any beds</span>
+                                    </summary>
+                                    <div class="listing-filter-popover">
+                                        <div class="listing-filter-menu-head">
+                                            <h3 class="listing-filter-menu-title">Bedrooms</h3>
+                                            <p class="listing-filter-menu-copy">Minimum bedrooms</p>
+                                        </div>
+                                        <label class="form-label" for="filter-min-bedrooms">Minimum bedrooms</label>
+                                        <select class="form-select" id="filter-min-bedrooms" name="min_bedrooms">
+                                            <option value="">Any beds</option>
+                                            <option value="1"{% if active_filters.min_bedrooms == "1" %} selected{% endif %}>1+ beds</option>
+                                            <option value="2"{% if active_filters.min_bedrooms == "2" %} selected{% endif %}>2+ beds</option>
+                                            <option value="3"{% if active_filters.min_bedrooms == "3" %} selected{% endif %}>3+ beds</option>
+                                            <option value="4"{% if active_filters.min_bedrooms == "4" %} selected{% endif %}>4+ beds</option>
+                                            <option value="5"{% if active_filters.min_bedrooms == "5" %} selected{% endif %}>5+ beds</option>
+                                        </select>
+                                    </div>
+                                </details>
+
+                                <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="baths">
+                                    <summary class="listing-filter-trigger">
+                                        <span class="listing-filter-trigger-label">Baths</span>
+                                        <span class="listing-filter-trigger-value" data-listings-filter-summary="baths">Any baths</span>
+                                    </summary>
+                                    <div class="listing-filter-popover">
+                                        <div class="listing-filter-menu-head">
+                                            <h3 class="listing-filter-menu-title">Bathrooms</h3>
+                                            <p class="listing-filter-menu-copy">Minimum bathrooms</p>
+                                        </div>
+                                        <label class="form-label" for="filter-min-bathrooms">Minimum bathrooms</label>
+                                        <select class="form-select" id="filter-min-bathrooms" name="min_bathrooms">
+                                            <option value="">Any baths</option>
+                                            <option value="1"{% if active_filters.min_bathrooms == "1" %} selected{% endif %}>1+ baths</option>
+                                            <option value="1.5"{% if active_filters.min_bathrooms == "1.5" %} selected{% endif %}>1.5+ baths</option>
+                                            <option value="2"{% if active_filters.min_bathrooms == "2" %} selected{% endif %}>2+ baths</option>
+                                            <option value="2.5"{% if active_filters.min_bathrooms == "2.5" %} selected{% endif %}>2.5+ baths</option>
+                                            <option value="3"{% if active_filters.min_bathrooms == "3" %} selected{% endif %}>3+ baths</option>
+                                        </select>
+                                    </div>
+                                </details>
+
+                                <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="price">
+                                    <summary class="listing-filter-trigger">
+                                        <span class="listing-filter-trigger-label">Price</span>
+                                        <span class="listing-filter-trigger-value" data-listings-filter-summary="price">Any price</span>
+                                    </summary>
+                                    <div class="listing-filter-popover">
+                                        <div class="listing-filter-menu-head">
+                                            <h3 class="listing-filter-menu-title">Price</h3>
+                                            <p class="listing-filter-menu-copy">Monthly rent</p>
+                                        </div>
+                                        <div class="listing-filter-select-grid">
+                                            <div>
+                                                <label class="form-label" for="filter-min-price">Minimum</label>
+                                                <select class="form-select" id="filter-min-price" name="min_price">
+                                                    <option value="">No min</option>
+                                                    <option value="750"{% if active_filters.min_price == "750" %} selected{% endif %}>$750+</option>
+                                                    <option value="1000"{% if active_filters.min_price == "1000" %} selected{% endif %}>$1,000+</option>
+                                                    <option value="1250"{% if active_filters.min_price == "1250" %} selected{% endif %}>$1,250+</option>
+                                                    <option value="1500"{% if active_filters.min_price == "1500" %} selected{% endif %}>$1,500+</option>
+                                                    <option value="2000"{% if active_filters.min_price == "2000" %} selected{% endif %}>$2,000+</option>
+                                                    <option value="2500"{% if active_filters.min_price == "2500" %} selected{% endif %}>$2,500+</option>
+                                                    <option value="3000"{% if active_filters.min_price == "3000" %} selected{% endif %}>$3,000+</option>
+                                                </select>
+                                            </div>
+                                            <div>
+                                                <label class="form-label" for="filter-max-price">Maximum</label>
+                                                <select class="form-select" id="filter-max-price" name="max_price">
+                                                    <option value="">No max</option>
+                                                    <option value="1000"{% if active_filters.max_price == "1000" %} selected{% endif %}>Up to $1,000</option>
+                                                    <option value="1250"{% if active_filters.max_price == "1250" %} selected{% endif %}>Up to $1,250</option>
+                                                    <option value="1500"{% if active_filters.max_price == "1500" %} selected{% endif %}>Up to $1,500</option>
+                                                    <option value="2000"{% if active_filters.max_price == "2000" %} selected{% endif %}>Up to $2,000</option>
+                                                    <option value="2500"{% if active_filters.max_price == "2500" %} selected{% endif %}>Up to $2,500</option>
+                                                    <option value="3000"{% if active_filters.max_price == "3000" %} selected{% endif %}>Up to $3,000</option>
+                                                    <option value="4000"{% if active_filters.max_price == "4000" %} selected{% endif %}>Up to $4,000</option>
+                                                </select>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </details>
+
+                                <details class="listing-filter-menu is-align-right" data-listings-filter-menu data-filter-name="filters">
+                                    <summary class="listing-filter-trigger">
+                                        <span class="listing-filter-trigger-label">Filters</span>
+                                        <span class="listing-filter-trigger-value" data-listings-filter-summary="filters">More</span>
+                                    </summary>
+                                    <div class="listing-filter-popover">
+                                        <div class="listing-filter-menu-head">
+                                            <h3 class="listing-filter-menu-title">More filters</h3>
+                                            <p class="listing-filter-menu-copy">Search, distance, dates, saved, and features</p>
+                                        </div>
+
+                                        <div class="listing-filter-stack">
+                                            <div>
+                                                <label class="form-label" for="filter-max-distance">Distance from campus</label>
+                                                <select class="form-select" id="filter-max-distance" name="max_distance">
+                                                    <option value="">Any distance</option>
+                                                    <option value="0.5"{% if active_filters.max_distance == "0.5" %} selected{% endif %}>Within 0.5 mi</option>
+                                                    <option value="1"{% if active_filters.max_distance == "1" %} selected{% endif %}>Within 1 mi</option>
+                                                    <option value="1.5"{% if active_filters.max_distance == "1.5" %} selected{% endif %}>Within 1.5 mi</option>
+                                                    <option value="2"{% if active_filters.max_distance == "2" %} selected{% endif %}>Within 2 mi</option>
+                                                    <option value="3"{% if active_filters.max_distance == "3" %} selected{% endif %}>Within 3 mi</option>
+                                                    <option value="5"{% if active_filters.max_distance == "5" %} selected{% endif %}>Within 5 mi</option>
+                                                </select>
+                                            </div>
+                                            <div class="listing-filter-date-grid">
+                                                <div>
+                                                    <label class="form-label" for="filter-availability-start">Move-in after</label>
+                                                    <input
+                                                        class="form-control"
+                                                        id="filter-availability-start"
+                                                        type="date"
+                                                        name="availability_start"
+                                                        value="{{ active_filters.availability_start }}"
+                                                    >
+                                                </div>
+                                                <div>
+                                                    <label class="form-label" for="filter-availability-end">Move-out before</label>
+                                                    <input
+                                                        class="form-control"
+                                                        id="filter-availability-end"
+                                                        type="date"
+                                                        name="availability_end"
+                                                        value="{{ active_filters.availability_end }}"
+                                                    >
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <label class="form-label" for="filter-saved">Saved listings</label>
+                                                <select class="form-select" id="filter-saved" name="saved">
+                                                    <option value="">All listings</option>
+                                                    <option value="1"{% if active_filters.saved %} selected{% endif %}>Saved only</option>
+                                                </select>
+                                            </div>
+                                            <div class="listing-filter-checkbox-grid">
+                                                <label class="listing-filter-checkbox-card">
+                                                    <input
+                                                        type="checkbox"
+                                                        name="has_parking"
+                                                        value="1"
+                                                        {% if active_filters.has_parking %}checked{% endif %}
+                                                    >
+                                                    <span>Parking</span>
+                                                </label>
+                                                <label class="listing-filter-checkbox-card">
+                                                    <input
+                                                        type="checkbox"
+                                                        name="is_furnished"
+                                                        value="1"
+                                                        {% if active_filters.is_furnished %}checked{% endif %}
+                                                    >
+                                                    <span>Furnished</span>
+                                                </label>
+                                                <label class="listing-filter-checkbox-card">
+                                                    <input
+                                                        type="checkbox"
+                                                        name="allows_pets"
+                                                        value="1"
+                                                        {% if active_filters.allows_pets %}checked{% endif %}
+                                                    >
+                                                    <span>Pets</span>
+                                                </label>
+                                                <label class="listing-filter-checkbox-card">
+                                                    <input
+                                                        type="checkbox"
+                                                        name="has_yard"
+                                                        value="1"
+                                                        {% if active_filters.has_yard %}checked{% endif %}
+                                                    >
+                                                    <span>Yard</span>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </details>
+                            </div>
+                        </form>
+                    </section>
+
+                    <div class="listing-browser-main">
+                        <aside class="listing-results-pane" data-listings-results data-listings-results-pane>
+                            <div class="listing-results-pane-head">
+                                <div>
+                                    <p class="listing-results-kicker">Listings feed</p>
+                                    <h2 class="listing-results-title">
+                                        {% if has_listing_only_access %}Owned listings{% else %}Visible listings{% endif %}
+                                    </h2>
+                                    <p class="listing-results-summary" data-listings-results-summary>
+                                        {{ listings_total }} result{{ listings_total|pluralize }}.
+                                    </p>
+                                </div>
+                                <div class="listing-results-pane-head-actions">
+                                    <span class="app-meta-chip app-meta-chip-neutral">Independent rail scroll</span>
+                                    <span class="app-meta-chip app-meta-chip-secondary">
+                                        {% if has_listing_only_access %}Inventory only{% else %}Viewport synced{% endif %}
+                                    </span>
+                                </div>
+                            </div>
 
                             {% if has_listing_only_access %}
                                 <div class="alert alert-warning listing-results-alert" role="alert">
@@ -306,36 +369,6 @@
                         </aside>
 
                         <section class="listing-map-pane" data-listings-map-pane data-listings-map-shell>
-                            <div class="listing-map-pane-head">
-                                <div>
-                                    <h2 class="listing-map-title">Map</h2>
-                                </div>
-                                <div class="listing-map-head-actions">
-                                    {% if listing_map_satellite_enabled %}
-                                        <div class="listing-map-style-toggle" role="group" aria-label="Map style">
-                                            <button
-                                                class="listing-map-style-button is-active"
-                                                type="button"
-                                                data-listings-map-style-toggle
-                                                data-style-mode="map"
-                                                aria-pressed="true"
-                                            >
-                                                Map
-                                            </button>
-                                            <button
-                                                class="listing-map-style-button"
-                                                type="button"
-                                                data-listings-map-style-toggle
-                                                data-style-mode="satellite"
-                                                aria-pressed="false"
-                                            >
-                                                Satellite
-                                            </button>
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </div>
-
                             <div
                                 class="listing-map-frame"
                                 data-listing-map-root
@@ -348,15 +381,55 @@
                                 data-default-lat="{{ listing_map_default_lat }}"
                                 data-default-lng="{{ listing_map_default_lng }}"
                             >
+                                <div class="listing-map-pane-head">
+                                    <div class="listing-map-head-copy">
+                                        <p class="listing-map-kicker">Spatial view</p>
+                                        <h2 class="listing-map-title">
+                                            {% if has_listing_only_access %}Inventory map{% else %}Market map{% endif %}
+                                        </h2>
+                                        <p class="listing-map-caption">Pinned to the viewport for continuous browsing.</p>
+                                    </div>
+                                    <div class="listing-map-head-actions">
+                                        {% if listing_map_satellite_enabled %}
+                                            <div class="listing-map-style-toggle" role="group" aria-label="Map style">
+                                                <button
+                                                    class="listing-map-style-button is-active"
+                                                    type="button"
+                                                    data-listings-map-style-toggle
+                                                    data-style-mode="map"
+                                                    aria-pressed="true"
+                                                >
+                                                    Map
+                                                </button>
+                                                <button
+                                                    class="listing-map-style-button"
+                                                    type="button"
+                                                    data-listings-map-style-toggle
+                                                    data-style-mode="satellite"
+                                                    aria-pressed="false"
+                                                >
+                                                    Satellite
+                                                </button>
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+
+                                <div class="listing-map-status-bar" aria-hidden="true">
+                                    <span class="listing-map-status-pill">Boston College anchor</span>
+                                    <span class="listing-map-status-pill">Live viewport refresh</span>
+                                </div>
+
                                 <div class="listing-map" data-listing-map-canvas data-listings-map-canvas></div>
+
+                                {% if not listing_initial_payload.markers %}
+                                    <div class="listing-map-note">
+                                        <h3 class="listing-map-note-title">No mapped listings yet.</h3>
+                                        <p class="listing-map-note-copy">Verified listings appear here as soon as they are ready for the market.</p>
+                                    </div>
+                                {% endif %}
                             </div>
 
-                            {% if not listing_initial_payload.markers %}
-                                <div class="listing-map-note">
-                                    <h3 class="listing-map-note-title">No mapped listings yet.</h3>
-                                    <p class="listing-map-note-copy">Verified listings show up here.</p>
-                                </div>
-                            {% endif %}
                         </section>
                     </div>
                 </section>

--- a/templates/listings/listing_list.html
+++ b/templates/listings/listing_list.html
@@ -41,43 +41,6 @@
             <section class="listing-browser-shell" data-listings-browser-shell>
                 <section class="listing-browser-workspace" data-listings-workspace>
                     <section class="listing-browser-command-deck">
-                        <div class="listing-browser-command-head">
-                            <div class="listing-browser-command-copy">
-                                <p class="listing-browser-kicker">
-                                    {% if has_listing_only_access %}Inventory map{% else %}Live market map{% endif %}
-                                </p>
-                                <h1 class="listing-browser-title">
-                                    {% if has_listing_only_access %}
-                                        Operate your listings from a fixed command deck.
-                                    {% else %}
-                                        Operate the market from a map-first workspace.
-                                    {% endif %}
-                                </h1>
-                                <p class="listing-browser-count">
-                                    {% if has_listing_only_access %}
-                                        The map stays pinned while the rail and controls update around your active inventory.
-                                    {% else %}
-                                        Horizontal controls keep search open, the listing rail scrolls independently, and the map stays locked in view.
-                                    {% endif %}
-                                </p>
-                            </div>
-                            <div class="listing-browser-command-meta">
-                                <span class="app-meta-chip app-meta-chip-primary">
-                                    {{ listings_total }} {% if has_listing_only_access %}owned{% else %}active{% endif %}
-                                </span>
-                                <span class="app-meta-chip app-meta-chip-secondary">
-                                    {% if active_filters.q or active_filters.min_bedrooms or active_filters.min_bathrooms or active_filters.min_price or active_filters.max_price or active_filters.lease_type or active_filters.max_distance or active_filters.availability_start or active_filters.availability_end or active_filters.has_parking or active_filters.is_furnished or active_filters.allows_pets or active_filters.has_yard or active_filters.saved %}
-                                        Filters active
-                                    {% elif has_listing_only_access %}
-                                        Inventory workspace
-                                    {% else %}
-                                        Map-first browsing
-                                    {% endif %}
-                                </span>
-                                <span class="app-meta-chip app-meta-chip-neutral">Drag map to refresh results</span>
-                            </div>
-                        </div>
-
                         <form
                             class="listing-results-filter-bar listing-results-filter-deck"
                             method="get"
@@ -85,7 +48,7 @@
                             data-listings-filters
                             data-listings-filter-form
                         >
-                            <div class="listing-filter-search-row listing-filter-search-row-deck">
+                            <div class="listing-filter-command-row">
                                 <div class="listing-filter-search-shell">
                                     <label class="visually-hidden" for="filter-query">Search listings</label>
                                     <input
@@ -97,13 +60,8 @@
                                         placeholder="Search by address, neighborhood, or title"
                                     >
                                 </div>
-                                <div class="listing-filter-deck-actions">
-                                    <span class="listing-filter-deck-label">Command deck</span>
-                                    <a class="listing-reset-link" href="{% url 'listings:listing_list' %}">Reset</a>
-                                </div>
-                            </div>
-                            <div class="listing-filter-toolbar-row listing-filter-toolbar-row-deck">
-                                <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="lease">
+                                <div class="listing-filter-toolbar-row listing-filter-toolbar-row-deck">
+                                    <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="lease">
                                     <summary class="listing-filter-trigger">
                                         <span class="listing-filter-trigger-label">Type</span>
                                         <span class="listing-filter-trigger-value" data-listings-filter-summary="lease">Any type</span>
@@ -125,7 +83,7 @@
                                     </div>
                                 </details>
 
-                                <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="beds">
+                                    <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="beds">
                                     <summary class="listing-filter-trigger">
                                         <span class="listing-filter-trigger-label">Beds</span>
                                         <span class="listing-filter-trigger-value" data-listings-filter-summary="beds">Any beds</span>
@@ -147,7 +105,7 @@
                                     </div>
                                 </details>
 
-                                <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="baths">
+                                    <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="baths">
                                     <summary class="listing-filter-trigger">
                                         <span class="listing-filter-trigger-label">Baths</span>
                                         <span class="listing-filter-trigger-value" data-listings-filter-summary="baths">Any baths</span>
@@ -169,7 +127,7 @@
                                     </div>
                                 </details>
 
-                                <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="price">
+                                    <details class="listing-filter-menu" data-listings-filter-menu data-filter-name="price">
                                     <summary class="listing-filter-trigger">
                                         <span class="listing-filter-trigger-label">Price</span>
                                         <span class="listing-filter-trigger-value" data-listings-filter-summary="price">Any price</span>
@@ -210,7 +168,7 @@
                                     </div>
                                 </details>
 
-                                <details class="listing-filter-menu is-align-right" data-listings-filter-menu data-filter-name="filters">
+                                    <details class="listing-filter-menu is-align-right" data-listings-filter-menu data-filter-name="filters">
                                     <summary class="listing-filter-trigger">
                                         <span class="listing-filter-trigger-label">Filters</span>
                                         <span class="listing-filter-trigger-value" data-listings-filter-summary="filters">More</span>
@@ -304,6 +262,10 @@
                                         </div>
                                     </div>
                                 </details>
+                                </div>
+                                <div class="listing-filter-deck-actions">
+                                    <a class="listing-reset-link" href="{% url 'listings:listing_list' %}">Reset</a>
+                                </div>
                             </div>
                         </form>
                     </section>
@@ -311,21 +273,9 @@
                     <div class="listing-browser-main">
                         <aside class="listing-results-pane" data-listings-results data-listings-results-pane>
                             <div class="listing-results-pane-head">
-                                <div>
-                                    <p class="listing-results-kicker">Listings feed</p>
-                                    <h2 class="listing-results-title">
-                                        {% if has_listing_only_access %}Owned listings{% else %}Visible listings{% endif %}
-                                    </h2>
-                                    <p class="listing-results-summary" data-listings-results-summary>
-                                        {{ listings_total }} result{{ listings_total|pluralize }}.
-                                    </p>
-                                </div>
-                                <div class="listing-results-pane-head-actions">
-                                    <span class="app-meta-chip app-meta-chip-neutral">Independent rail scroll</span>
-                                    <span class="app-meta-chip app-meta-chip-secondary">
-                                        {% if has_listing_only_access %}Inventory only{% else %}Viewport synced{% endif %}
-                                    </span>
-                                </div>
+                                <p class="listing-results-summary" data-listings-results-summary>
+                                    {{ listings_total }} result{{ listings_total|pluralize }}.
+                                </p>
                             </div>
 
                             {% if has_listing_only_access %}
@@ -381,16 +331,9 @@
                                 data-default-lat="{{ listing_map_default_lat }}"
                                 data-default-lng="{{ listing_map_default_lng }}"
                             >
-                                <div class="listing-map-pane-head">
-                                    <div class="listing-map-head-copy">
-                                        <p class="listing-map-kicker">Spatial view</p>
-                                        <h2 class="listing-map-title">
-                                            {% if has_listing_only_access %}Inventory map{% else %}Market map{% endif %}
-                                        </h2>
-                                        <p class="listing-map-caption">Pinned to the viewport for continuous browsing.</p>
-                                    </div>
-                                    <div class="listing-map-head-actions">
-                                        {% if listing_map_satellite_enabled %}
+                                {% if listing_map_satellite_enabled %}
+                                    <div class="listing-map-pane-head">
+                                        <div class="listing-map-head-actions">
                                             <div class="listing-map-style-toggle" role="group" aria-label="Map style">
                                                 <button
                                                     class="listing-map-style-button is-active"
@@ -411,14 +354,9 @@
                                                     Satellite
                                                 </button>
                                             </div>
-                                        {% endif %}
+                                        </div>
                                     </div>
-                                </div>
-
-                                <div class="listing-map-status-bar" aria-hidden="true">
-                                    <span class="listing-map-status-pill">Boston College anchor</span>
-                                    <span class="listing-map-status-pill">Live viewport refresh</span>
-                                </div>
+                                {% endif %}
 
                                 <div class="listing-map" data-listing-map-canvas data-listings-map-canvas></div>
 


### PR DESCRIPTION
## Summary
- redesign the map-first listings page into a locked viewport workspace with internal scrolling only in the results rail
- move the search and filter controls into a compact single-row command rail across the full page width
- tighten the map chrome by removing nonessential copy and pinning the map/satellite toggle as a compact top-left control

## What Changed
- rebuilt the listings map page shell so the map stays fixed to the viewport, the footer is hidden on the map surface, and desktop page scrolling is disabled below the map
- upgraded the left rail presentation with denser horizontal result cards, a compact results header, and stronger enterprise-style pane hierarchy
- compressed the control rail so search, filters, and reset sit on one line on desktop/tablet and only wrap again at the mobile breakpoint
- repositioned the map style toggle into a small top-left overlay instead of a broader header treatment
- updated the listings page contract test to match the new map-first layout hooks

## Verification
- `./.venv/bin/ruff check .`
- `./.venv/bin/ruff format --check .`
- `./.venv/bin/python manage.py check`
- `./.venv/bin/python manage.py test`
